### PR TITLE
extend Accounts page with CreatedAt and PublicKey for Users

### DIFF
--- a/Lexplorer/Helpers/GraphQLFragments.cs
+++ b/Lexplorer/Helpers/GraphQLFragments.cs
@@ -18,12 +18,46 @@
                 }
               }";
 
+        //to avoid recursion in User/PoolFragments for accountCreatedAt, use an un-nested fragment
+        //otherwise the transaction belongs to a block, which has an operator, which again is a pool
+        public static string AccountCreatedAtFragment = @"
+            fragment AccountCreatedAtFragment on Transaction {
+                id
+                __typename
+                block {
+                  id
+                  timestamp
+                }
+            }";
+
         public static string AccountFragment = @"
             fragment AccountFragment on Account {
                 id
                 address
                 __typename
             }";
+
+        public static string UserFragment = @"
+            fragment UserFragment on User {
+                id
+                address
+                __typename
+                createdAtTransaction {
+                  ...AccountCreatedAtFragment
+                }
+                publicKey
+              }";
+
+        public static string PoolFragment = @"
+            fragment PoolFragment on Pool {
+                id
+                address
+                __typename
+                createdAtTransaction {
+                  ...AccountCreatedAtFragment
+                }
+                feeBipsAMM
+              }";
 
         public static string TokenFragment = @"
             fragment TokenFragment on Token {
@@ -32,19 +66,6 @@
                 symbol
                 decimals
                 address
-              }";
-
-        public static string PoolFragment = @"
-            fragment PoolFragment on Pool {
-                id
-                address
-                balances {
-                  id
-                  balance
-                  token {
-                    ...TokenFragment
-                  }
-                }
               }";
 
         public static string NFTFragment = @"

--- a/Lexplorer/Models/LoopringV3.cs
+++ b/Lexplorer/Models/LoopringV3.cs
@@ -89,6 +89,7 @@ namespace Lexplorer.Models
         [JsonProperty("__typename")]
         public string? typeName { get; set; }
         public List<AccountBalance>? balances { get; set; }
+        public Transaction? createdAtTransaction { get; set; }
     }
 
     public class Pool : Account

--- a/Lexplorer/Models/LoopringV3.cs
+++ b/Lexplorer/Models/LoopringV3.cs
@@ -119,6 +119,12 @@ namespace Lexplorer.Models
         public string? id { get; set; }
         public Token? token { get; set; }
         public Account? account { get; set; }
+        public Double fBalance {
+            get
+            {
+                return balance / Math.Pow(10, token!.decimals);
+            }
+        }
     }
 
     public class User : Account

--- a/Lexplorer/Pages/Account.razor
+++ b/Lexplorer/Pages/Account.razor
@@ -9,8 +9,10 @@
 
 @if (account != null)
 {
-            <MudText Typo="Typo.h6">Account #@account.id</MudText>
-            <MudSimpleTable Dense="true">
+            <MudSimpleTable Dense="true" Striped="true" Bordered="true">
+                <div class="mud-toolbar mud-toolbar-gutters mud-table-toolbar">
+                    <MudText Typo="Typo.h6">@account.typeName #@account.id</MudText>
+                </div>
                 <tbody>
                     <tr>
                         <td>L1 Address</td>
@@ -37,18 +39,24 @@
 
             <br />
 
-            <MudTable Dense="true" Items="@account.balances" Hover="true" Loading=@balancesLoadíng>
+            <MudTable Dense="true" Striped="true" Bordered="true" Items="@account.balances" Hover="true" Loading=@balancesLoadíng>
                 <ToolBarContent>
                     <MudText Typo="Typo.h6">Token balances</MudText>
                 </ToolBarContent>
                 <HeaderContent>
-                    <MudTh>Token</MudTh>
-                    <MudTh>Balance</MudTh>
+                    <MudTh Style="text-align:right"><MudTableSortLabel SortBy="new Func<AccountBalance, object>(x=>x.token!.name!)">Token</MudTableSortLabel></MudTh>
+                    <MudTh><MudTableSortLabel SortBy="new Func<AccountBalance, object>(x=>x.fBalance!)">Balance</MudTableSortLabel></MudTh>
                 </HeaderContent>
                 <RowTemplate>
-                    <MudTd DataLabel="Token">@context.token!.name</MudTd>
+                    <MudTd Style="text-align:right" DataLabel="Token">@context.token!.name</MudTd>
                     <MudTd DataLabel="Balance">@TokenAmountConverter.Convert(@context.balance, @context.token!.decimals) @context.token.symbol</MudTd>                
                 </RowTemplate>
+                <PagerContent>
+            @if (account.balances!.Count > 10)
+            {
+                    <MudTablePager InfoFormat="@("{first_item}-{last_item} of {all_items}")" HorizontalAlignment="HorizontalAlignment.Left"/>
+            }
+                </PagerContent>
             </MudTable>
 }
 else
@@ -59,7 +67,7 @@ else
 
 @if (transactions != null)
 {
-            <MudTable Dense="true" Items="@transactions" Hover="true" Loading=@isLoading>
+            <MudTable Dense="true" Striped="true" Bordered="true" Items="@transactions" Hover="true" Loading=@isLoading>
                 <ToolBarContent>
                     <MudText Typo="Typo.h6">Transactions</MudText>
                 </ToolBarContent>

--- a/Lexplorer/Pages/Account.razor
+++ b/Lexplorer/Pages/Account.razor
@@ -22,9 +22,17 @@
                     </tr>
                     <tr>
                         <td>Created At (UTC)</td>
-                        <td>todo</td>
+                        <td>@account.createdAtTransaction!.verifiedAt</td>
                     </tr>
-                </tbody>
+            @if (account is User)
+            {
+                    <tr>
+                        <td>Public key</td>
+                        <td>0x@((account as User)!.publicKey)</td>
+                    </tr>
+                
+            }
+        </tbody>
             </MudSimpleTable>
 
             <br />
@@ -122,6 +130,7 @@ else
         {
             balancesLoadíng = true;
             account = await GraphQLService.GetAccount(accountId);
+            if (account == null) return;
             StateHasChanged();
             account!.balances = await GraphQLService.GetAccountBalance(accountId);
             balancesLoadíng = false;

--- a/Lexplorer/Services/GraphQLService.cs
+++ b/Lexplorer/Services/GraphQLService.cs
@@ -151,6 +151,7 @@ namespace Lexplorer.Services
               + GraphQLFragments.AccountFragment
               + GraphQLFragments.TokenFragment
               + GraphQLFragments.PoolFragment
+              + GraphQLFragments.AccountCreatedAtFragment
               + GraphQLFragments.NFTFragment
               + GraphQLFragments.AddFragment
               + GraphQLFragments.RemoveFragment
@@ -181,9 +182,9 @@ namespace Lexplorer.Services
                 }
             });
 
-            var response = await _client.PostAsync(request);
             try
             {
+                var response = await _client.PostAsync(request);
                 JObject jresponse = JObject.Parse(response.Content!);
                 JToken result = jresponse["data"]!["transaction"]!;
                 return result.ToObject<Transaction>();
@@ -195,7 +196,7 @@ namespace Lexplorer.Services
             }
         }
 
-        public async Task<Transactions> GetTransactions(int skip, int first, string? blockId = null, string? typeName = null)
+        public async Task<Transactions?> GetTransactions(int skip, int first, string? blockId = null, string? typeName = null)
         {
             Debug.WriteLine(blockId);
             var transactionsQuery = @"
@@ -280,6 +281,7 @@ namespace Lexplorer.Services
               + GraphQLFragments.AccountFragment
               + GraphQLFragments.TokenFragment
               + GraphQLFragments.PoolFragment
+              + GraphQLFragments.AccountCreatedAtFragment
               + GraphQLFragments.NFTFragment
               + GraphQLFragments.AddFragment
               + GraphQLFragments.RemoveFragment
@@ -353,9 +355,17 @@ namespace Lexplorer.Services
                 });
             }
 
-            var response = await _client.PostAsync(request);
-            var data = JsonConvert.DeserializeObject<Transactions>(response.Content!);
-            return data;
+            try
+            { 
+                var response = await _client.PostAsync(request);
+                var data = JsonConvert.DeserializeObject<Transactions>(response.Content!);
+                return data;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine(ex.Message);
+                return null;
+            }
         }
         public async Task<Account?> GetAccount(string accountId)
         {
@@ -366,10 +376,14 @@ namespace Lexplorer.Services
                 account(
                   id: $accountId
                 ) {
-                  ...AccountFragment 
+                  ...PoolFragment
+                  ...UserFragment
                 }
             }"
-            + GraphQLFragments.AccountFragment;
+            + GraphQLFragments.PoolFragment
+            + GraphQLFragments.UserFragment
+            + GraphQLFragments.AccountCreatedAtFragment
+            + GraphQLFragments.BlockFragment;
 
             var request = new RestRequest();
             request.AddHeader("Content-Type", "application/json");
@@ -381,9 +395,9 @@ namespace Lexplorer.Services
                     accountId = int.Parse(accountId)
                 }
             });
-            var response = await _client.PostAsync(request);
             try
             {
+                var response = await _client.PostAsync(request);
                 JObject jresponse = JObject.Parse(response.Content!);
                 JToken result = jresponse["data"]!["account"]!;
                 return result.ToObject<Account>()!;
@@ -500,6 +514,7 @@ namespace Lexplorer.Services
               + GraphQLFragments.AccountFragment
               + GraphQLFragments.TokenFragment
               + GraphQLFragments.PoolFragment
+              + GraphQLFragments.AccountCreatedAtFragment
               + GraphQLFragments.NFTFragment
               + GraphQLFragments.AddFragment
               + GraphQLFragments.RemoveFragment


### PR DESCRIPTION
* removed balances from PoolFragment - not used AFAICs
** the balances of each account are retrieved in a separate query,
   see GetAccountBalance
* added specific fields and createdAtTransaction to User and Pool
  fragments
** used a separate more limited fragment for createdAtTransaction to
   avoid recurcsion like Pool.createdAtTransaction.block.operator
** added fragment to all queries which had Pool and UserFragments
* as this whole episode caused lots of troubles with malformed queries,
  hardened code in GraphQLService so exceptions are caught and logged