### PR TITLE
Implemented basic search on homepage

### DIFF
--- a/Lexplorer/Components/DepositTransactionDetail.razor
+++ b/Lexplorer/Components/DepositTransactionDetail.razor
@@ -24,7 +24,7 @@
                             </tr>
                             <tr>
                                 <td>Deposited From</td>
-                                <td>@AccountLinkHelper.CreateUserLink(DepositDetails.toAccount!, false)</td>
+                                <td>@LinkHelper.CreateUserLink(DepositDetails.toAccount!, false)</td>
                             </tr>
                             <tr>
                                 <td>Amount</td>

--- a/Lexplorer/Components/HomepageOverview.razor
+++ b/Lexplorer/Components/HomepageOverview.razor
@@ -7,19 +7,15 @@
 @inject IAppCache AppCache;
 
     <MudGrid>
-        <p hidden="@(transactionData != null)">
-            <MudItem sm="12">
-                <MudProgressLinear Color="Color.Primary" Indeterminate="true" Class="my-7"/>
-            </MudItem>
-        </p>
-        <MudItem sm="12" Class="d-flex justify-center flex-grow-1 gap-4">
-            <MudTextField  @bind-Value="searchTerm" Label="Search account, block or transaction" Variant="Variant.Outlined" Adornment="Adornment.End" AdornmentIcon="@Icons.Filled.Search" AdornmentColor="Color.Secondary" OnAdornmentClick="DoSearch" />
+        <MudItem sm="12">
+            <p hidden="@(transactionData != null)"><MudProgressLinear Color="Color.Primary" Indeterminate="true" Class="my-7"/></p>
         </MudItem>
-        <p hidden="@(!searching)">
-            <MudItem sm="12">
-                <MudProgressLinear Color="Color.Secondary" Indeterminate="true" Class="my-7"/>
-            </MudItem>
-        </p>
+        <MudItem sm="12">
+            <MudTextField @bind-Value="searchTerm" Label="Search account, block or transaction" Variant="Variant.Outlined" Adornment="Adornment.End" AdornmentIcon="@Icons.Filled.Search" AdornmentColor="Color.Secondary" OnAdornmentClick="DoSearch" />
+        </MudItem>
+        <MudItem sm="12">
+            <p hidden="@(!searching)"><MudProgressLinear Color="Color.Secondary" Indeterminate="true" Class="my-7"/></p>
+        </MudItem>
         <MudItem sm="12">
             <MudTable Dense="true" Striped="true" Bordered="true" Items="@searchResults" Hover="true">
                 <ToolBarContent>

--- a/Lexplorer/Components/HomepageOverview.razor
+++ b/Lexplorer/Components/HomepageOverview.razor
@@ -26,7 +26,7 @@
                     <MudTh>Type</MudTh>
                 </HeaderContent>
                 <RowTemplate>
-                    <MudTd DataLabel="Found">@(context.GetType()?.GetProperty("id")?.GetValue(context, null))</MudTd>
+                    <MudTd DataLabel="Found">@LinkHelper.GetObjectLink(context)</MudTd>
                     <MudTd DataLabel="Type">@(context.GetType()?.GetProperty("typeName")?.GetValue(context, null))</MudTd>                
                 </RowTemplate>
             </MudTable>
@@ -301,6 +301,12 @@
         searchResults = null;
         StateHasChanged();
         searchResults = await LoopringGraphQLService.Search(searchTerm);
+        if (searchResults?.Count == 1)
+        {
+            Tuple<string, string>? adr = LinkHelper.GetObjectLinkAddress(searchResults[0]);
+            if (!string.IsNullOrEmpty(adr?.Item1))
+                NavigationManager.NavigateTo(adr.Item1);
+        }
         searching = false;
         StateHasChanged();
     }

--- a/Lexplorer/Components/HomepageOverview.razor
+++ b/Lexplorer/Components/HomepageOverview.razor
@@ -191,7 +191,7 @@
     private decimal? priceOfToken(Token token)
     {
         //find token.address in uniswapTokens and get most recent price; if not available, return 1.0 so no conversion
-        return uniswapTokens?.Where(c => c.address == @token?.address).First()?.data?.tokenDayDatas?[0].priceUSD;
+        return uniswapTokens?.Where(c => c.address == @token?.address).FirstOrDefault()?.data?.tokenDayDatas?[0].priceUSD;
     }
 
     private string? getVolumePair1(Pair pair, Boolean weekly = true)

--- a/Lexplorer/Components/HomepageOverview.razor
+++ b/Lexplorer/Components/HomepageOverview.razor
@@ -6,20 +6,13 @@
 @inject NavigationManager NavigationManager;
 @inject IAppCache AppCache;
 
-@if (blockData == null && transactionData == null && pairsData == null && uniswapTokens == null)
-{
-    <br />
-    <MudProgressCircular Color="Color.Primary" Indeterminate="true" />
-}
-else if (blockData != null && transactionData != null && pairsData != null && uniswapTokens != null)
-{
-
+    <p hidden="@(transactionData != null)"><MudProgressLinear Color="Color.Primary" Indeterminate="true" Class="my-7"/></p>
     <MudGrid>
         <MudItem sm="4">
             <MudCard>
                 <MudCardContent>
                     <MudText Typo="Typo.h6" Align="Align.Center">Total Transactions</MudText>
-                    <MudText Typo="Typo.body1" Align="Align.Center">@transactionData.data!.proxy!.transactionCount</MudText>
+                    <MudText Typo="Typo.body1" Align="Align.Center">@blockData?.data?.proxy?.transactionCount.ToString("N0")</MudText>
                 </MudCardContent>
             </MudCard>
         </MudItem>
@@ -27,7 +20,7 @@ else if (blockData != null && transactionData != null && pairsData != null && un
             <MudCard>
                 <MudCardContent>
                     <MudText Typo="Typo.h6" Align="Align.Center">Total Blocks</MudText>
-                    <MudText Typo="Typo.body1" Align="Align.Center">@blockData.data!.proxy!.blockCount</MudText>
+                    <MudText Typo="Typo.body1" Align="Align.Center">@blockData?.data?.proxy?.blockCount.ToString("N0")</MudText>
                 </MudCardContent>
             </MudCard>
         </MudItem>
@@ -35,7 +28,7 @@ else if (blockData != null && transactionData != null && pairsData != null && un
             <MudCard>
                 <MudCardContent>
                     <MudText Typo="Typo.h6" Align="Align.Center">Total L2 Accounts</MudText>
-                    <MudText Typo="Typo.body1" Align="Align.Center">@blockData.data!.proxy!.userCount</MudText>
+                    <MudText Typo="Typo.body1" Align="Align.Center">@blockData?.data?.proxy?.userCount.ToString("N0")</MudText>
                 </MudCardContent>
             </MudCard>
         </MudItem>
@@ -53,7 +46,7 @@ else if (blockData != null && transactionData != null && pairsData != null && un
             <MudCard>
                 <MudCardContent>
                     <MudText Typo="Typo.h6" Align="Align.Center">Average Transactions per Block</MudText>
-                    <MudText Typo="Typo.body1" Align="Align.Center">@averageTransactions</MudText>
+                    <MudText Typo="Typo.body1" Align="Align.Center">@averageTransactions.ToString("N0")</MudText>
                 </MudCardContent>
             </MudCard>
         </MudItem>
@@ -71,7 +64,7 @@ else if (blockData != null && transactionData != null && pairsData != null && un
             <MudCard>
                 <MudCardContent>
                     <MudText Typo="Typo.h6" Align="Align.Center">NFT Mint Count</MudText>
-                    <MudText Typo="Typo.body1" Align="Align.Center">@transactionData.data!.proxy!.nftMintCount</MudText>
+                    <MudText Typo="Typo.body1" Align="Align.Center">@blockData?.data?.proxy?.nftMintCount.ToString("N0")</MudText>
                 </MudCardContent>
             </MudCard>
         </MudItem>
@@ -79,7 +72,7 @@ else if (blockData != null && transactionData != null && pairsData != null && un
             <MudCard>
                 <MudCardContent>
                     <MudText Typo="Typo.h6" Align="Align.Center">NFT Trade Count</MudText>
-                    <MudText Typo="Typo.body1" Align="Align.Center">@transactionData.data!.proxy!.tradeNFTCount</MudText>
+                    <MudText Typo="Typo.body1" Align="Align.Center">@blockData?.data?.proxy?.tradeNFTCount.ToString("N0")</MudText>
                 </MudCardContent>
             </MudCard>
         </MudItem>
@@ -87,15 +80,15 @@ else if (blockData != null && transactionData != null && pairsData != null && un
             <MudCard>
                 <MudCardContent>
                     <MudText Typo="Typo.h6" Align="Align.Center">NFT Transfer Count</MudText>
-                    <MudText Typo="Typo.body1" Align="Align.Center">@transactionData.data!.proxy!.transferNFTCount</MudText>
+                    <MudText Typo="Typo.body1" Align="Align.Center">@blockData?.data?.proxy?.transferNFTCount.ToString("N0")</MudText>
                 </MudCardContent>
             </MudCard>
         </MudItem>
     </MudGrid>
 
     <MudGrid>
-        <MudItem sm="6">
-            <MudTable Dense="true" Items="@blockData.data!.blocks" Hover="true">
+        <MudItem sm="5">
+            <MudTable Dense="true" Items="@blockData?.data?.blocks" Hover="true">
                 <ToolBarContent>
                     <MudText Typo="Typo.h6">Latest Blocks</MudText>
                 </ToolBarContent>
@@ -114,8 +107,8 @@ else if (blockData != null && transactionData != null && pairsData != null && un
             </MudTable>
             <MudButton Variant="Variant.Filled" Color="Color.Primary" FullWidth="true" OnClick="GoToBlockOverviewPage">View more blocks</MudButton>
         </MudItem>
-        <MudItem sm="6">
-            <MudTable Dense="true" Items="@transactionData.data!.transactions" Hover="true">
+        <MudItem sm="7">
+            <MudTable Dense="true" Items="@transactionData?.data?.transactions" Hover="true">
                 <ToolBarContent>
                     <MudText Typo="Typo.h6">Latest Transactions</MudText>
                 </ToolBarContent>
@@ -132,33 +125,34 @@ else if (blockData != null && transactionData != null && pairsData != null && un
                     <MudTd DataLabel="Transaction Id"><a Class="mud-theme-primary" href=@ParameterHelper.ConvertToTransactionLink(@context.typeName!, @context.id!)>@context.id</a></MudTd>
                     <MudTd DataLabel="Type">@context.typeName</MudTd>
                     <TransactionTableDetails TransactionData=@context />
-                    <MudTd DataLabel="Timestamp">@TimestampConverter.ToUTCString(@blockData.data!.blocks![0].timestamp!)</MudTd>
+                    <MudTd DataLabel="Timestamp">@TimestampConverter.ToUTCString(@blockData?.data?.blocks?[0].timestamp)</MudTd>
                 </RowTemplate>
             </MudTable>
             <MudButton Variant="Variant.Filled" Color="Color.Primary" FullWidth="true" OnClick="GoToTransactionOverviewPage">View more transactions</MudButton>
         </MudItem>
     </MudGrid>
      <MudGrid>
-        <MudItem sm="6">
-            <MudTable Dense="true" Items="@pairsData.data!.pairs" Hover="true">
+        <MudItem sm="5">
+            <MudTable Dense="true" Items="@pairsData?.data?.pairs" Hover="true">
                 <ToolBarContent>
                     <MudText Typo="Typo.h6">Pairs</MudText>
                 </ToolBarContent>
                 <HeaderContent>
                     <MudTh>Pair</MudTh>
                     <MudTh Style="text-align:right">Volume 24H</MudTh>
+                    <MudTh Style="text-align:right">24H % avg</MudTh>
                     <MudTh Style="text-align:right">Volume 7D</MudTh>
                 </HeaderContent>
                 <RowTemplate>
                     <MudTd DataLabel="Pair">@context.token0!.symbol/@context.token1!.symbol</MudTd>
-                    <MudTd Style="text-align:right" DataLabel="Volume 24H">$@TokenAmountConverter.ToStringWithExponent(@context.dailyEntities![0].tradedVolumeToken1Swap, @context.token1!.decimals, uniswapTokens!.Where(c => c.address! == @context.token1!.address).First()!.data!.tokenDayDatas![0].priceUSD) </MudTd>
-                    <MudTd Style="text-align:right" DataLabel="Volume 7D">$@TokenAmountConverter.ToStringWithExponent(@context.weeklyEntities![0].tradedVolumeToken1Swap, @context.token1!.decimals, uniswapTokens!.Where(c => c.address! == @context.token1!.address).First()!.data!.tokenDayDatas![0].priceUSD) </MudTd>
+                    <MudTd Style="text-align:right" DataLabel="Volume 24H">@getVolumePair1(context, false)</MudTd>
+                    <MudTd Style="text-align:right" DataLabel="24H % avg">@get24hPercentage(context) %</MudTd>
+                    <MudTd Style="text-align:right" DataLabel="Volume 7D">@getVolumePair1(context)</MudTd>
                 </RowTemplate>
             </MudTable>
             <MudButton Variant="Variant.Filled" Color="Color.Primary" FullWidth="true" OnClick="GoToPairOverviewPage">View more pairs</MudButton>
         </MudItem>
     </MudGrid>
-}
 
 @code
 {
@@ -171,12 +165,41 @@ else if (blockData != null && transactionData != null && pairsData != null && un
     private long averageTransactions;
     private double lastBlockSubmittedTime;
 
+    private decimal? priceOfToken(Token token)
+    {
+        //find token.address in uniswapTokens and get most recent price; if not available, return 1.0 so no conversion
+        return uniswapTokens?.Where(c => c.address == @token?.address).First()?.data?.tokenDayDatas?[0].priceUSD;
+    }
+
+    private string? getVolumePair1(Pair pair, Boolean weekly = true)
+    {
+        if (pair == null) return null;
+        decimal? price = (pair.token1 == null) ? null : priceOfToken(pair.token1);
+        var volume = weekly
+            ? pair.weeklyEntities![0].tradedVolumeToken1Swap
+            : pair.dailyEntities![0].tradedVolumeToken1Swap;
+        if (price.HasValue)
+            return $"${@TokenAmountConverter.ToStringWithExponent(volume, pair.token1?.decimals ?? 0, price.Value)}";
+        else
+            return $"{pair.token1?.symbol} {@TokenAmountConverter.ToStringWithExponent(volume, pair.token1?.decimals ?? 0, 1)}";
+    }
+
+    private string? get24hPercentage(Pair pair)
+    {
+        if (pair == null) return null;
+        return (pair.dailyEntities![0].tradedVolumeToken1Swap * 7 / pair.weeklyEntities![0].tradedVolumeToken1Swap * 100).ToString("N2");
+    }
+
     protected override async Task OnInitializedAsync()
     {
         string blockCacheKey = $"homepage-block";
         blockData = await AppCache.GetOrAddAsync(blockCacheKey, async () => await LoopringGraphQLService.GetBlocks(0, 10), DateTimeOffset.UtcNow.AddMinutes(10));
+        CalculateAverageBlockTime();
+        CalculateLastBlockSubmitted();
+        StateHasChanged();
         string transactionCacheKey = $"homepage-transaction";
         transactionData = await AppCache.GetOrAddAsync(transactionCacheKey, async () => await LoopringGraphQLService.GetTransactions(0, 10), DateTimeOffset.UtcNow.AddMinutes(10));
+        StateHasChanged();
         string pairsCacheKey = $"homepage-pairs";
         pairsData = await AppCache.GetOrAddAsync(pairsCacheKey, async () => await LoopringGraphQLService.GetPairs(), DateTimeOffset.UtcNow.AddHours(1));
         int pairCount = 0;
@@ -195,8 +218,6 @@ else if (blockData != null && transactionData != null && pairsData != null && un
             }
             pairCount++;
         }
-        CalculateAverageBlockTime();
-        CalculateLastBlockSubmitted();
         StateHasChanged();
     }
 

--- a/Lexplorer/Components/HomepageOverview.razor
+++ b/Lexplorer/Components/HomepageOverview.razor
@@ -6,8 +6,35 @@
 @inject NavigationManager NavigationManager;
 @inject IAppCache AppCache;
 
-    <p hidden="@(transactionData != null)"><MudProgressLinear Color="Color.Primary" Indeterminate="true" Class="my-7"/></p>
     <MudGrid>
+        <p hidden="@(transactionData != null)">
+            <MudItem sm="12">
+                <MudProgressLinear Color="Color.Primary" Indeterminate="true" Class="my-7"/>
+            </MudItem>
+        </p>
+        <MudItem sm="12" Class="d-flex justify-center flex-grow-1 gap-4">
+            <MudTextField  @bind-Value="searchTerm" Label="Search account, block or transaction" Variant="Variant.Outlined" Adornment="Adornment.End" AdornmentIcon="@Icons.Filled.Search" AdornmentColor="Color.Secondary" OnAdornmentClick="DoSearch" />
+        </MudItem>
+        <p hidden="@(!searching)">
+            <MudItem sm="12">
+                <MudProgressLinear Color="Color.Secondary" Indeterminate="true" Class="my-7"/>
+            </MudItem>
+        </p>
+        <MudItem sm="12">
+            <MudTable Dense="true" Striped="true" Bordered="true" Items="@searchResults" Hover="true">
+                <ToolBarContent>
+                    <MudText Typo="Typo.h6">Search results for "@searchTerm"</MudText>
+                </ToolBarContent>
+                <HeaderContent>
+                    <MudTh>Found</MudTh>
+                    <MudTh>Type</MudTh>
+                </HeaderContent>
+                <RowTemplate>
+                    <MudTd DataLabel="Found">@(context.GetType()?.GetProperty("id")?.GetValue(context, null))</MudTd>
+                    <MudTd DataLabel="Type">@(context.GetType()?.GetProperty("typeName")?.GetValue(context, null))</MudTd>                
+                </RowTemplate>
+            </MudTable>
+        </MudItem>
         <MudItem sm="4">
             <MudCard>
                 <MudCardContent>
@@ -249,7 +276,7 @@
         NavigationManager.NavigateTo(parameters);
     }
 
-private void GoToPairOverviewPage()
+    private void GoToPairOverviewPage()
     {
         string parameters = "pairs?pageNumber=0";
         NavigationManager.NavigateTo(parameters);
@@ -261,5 +288,25 @@ private void GoToPairOverviewPage()
         NavigationManager.NavigateTo(parameters);
     }
 
+    private IList<object>? searchResults;
+    private Boolean searching = false;
+    private string? _searchTerm;
+    private string? searchTerm { get { return _searchTerm; } 
+        set
+        {
+            _searchTerm = value;
+            DoSearch();
+        }
+    }
+    private async void DoSearch()
+    {
+        if (searchTerm == null) return;
+        searching = true;
+        searchResults = null;
+        StateHasChanged();
+        searchResults = await LoopringGraphQLService.Search(searchTerm);
+        searching = false;
+        StateHasChanged();
+    }
 
 }

--- a/Lexplorer/Components/OrderbookTradeTransactionDetail.razor
+++ b/Lexplorer/Components/OrderbookTradeTransactionDetail.razor
@@ -23,11 +23,11 @@
                                 </tr>
                                 <tr>
                                     <td>Account 1</td>
-                                    <td>@AccountLinkHelper.CreateUserLink(TradeDetails.accountA!, false)</td>
+                                    <td>@LinkHelper.CreateUserLink(TradeDetails.accountA!, false)</td>
                                 </tr>
                                 <tr>
                                     <td>Account 2</td>
-                                    <td>@AccountLinkHelper.CreateUserLink(TradeDetails.accountB!, false)</td>
+                                    <td>@LinkHelper.CreateUserLink(TradeDetails.accountB!, false)</td>
                                 </tr>
                                 <tr>
                                     <td>Trade</td>

--- a/Lexplorer/Components/SwapTransactionDetail.razor
+++ b/Lexplorer/Components/SwapTransactionDetail.razor
@@ -23,7 +23,7 @@
                             </tr>
                             <tr>
                                 <td>User Account</td>
-                                <td>@AccountLinkHelper.CreateUserLink(SwapDetails.account!, false)</td>
+                                <td>@LinkHelper.CreateUserLink(SwapDetails.account!, false)</td>
                             </tr>
                             <tr>
                                 <td>Swap</td>
@@ -35,7 +35,7 @@
                             </tr>
                             <tr>
                                 <td>Pool</td>
-                                <td>@AccountLinkHelper.CreateUserLink(SwapDetails.pool!, false)</td>
+                                <td>@LinkHelper.CreateUserLink(SwapDetails.pool!, false)</td>
                             </tr>
                             <tr>
                                 <td>Raw Data</td>

--- a/Lexplorer/Components/TransactionTableDetails.razor
+++ b/Lexplorer/Components/TransactionTableDetails.razor
@@ -6,19 +6,19 @@
 {
     case "Deposit":
         <MudTd DataLabel="From Address"></MudTd>
-        <MudTd DataLabel="To Address">@AccountLinkHelper.CreateUserLink(deposit?.toAccount, ignoreUserIDForLink)</MudTd>
+        <MudTd DataLabel="To Address">@LinkHelper.CreateUserLink(deposit?.toAccount, ignoreUserIDForLink)</MudTd>
         <MudTd DataLabel="Amount" Style="text-align:right" >@TokenAmountConverter.ToString(deposit!.amount, deposit!.token!.decimals) @deposit!.token!.symbol</MudTd>
         <MudTd DataLabel="Fee"></MudTd>
         break;
     case "Withdrawal":
-        <MudTd DataLabel="From Address">@AccountLinkHelper.CreateUserLink(withdrawal?.fromAccount, ignoreUserIDForLink)</MudTd>
+        <MudTd DataLabel="From Address">@LinkHelper.CreateUserLink(withdrawal?.fromAccount, ignoreUserIDForLink)</MudTd>
         <MudTd DataLabel="To Address"></MudTd>
         <MudTd DataLabel="Amount" Style="text-align:right" >@TokenAmountConverter.ToString(withdrawal?.amount, withdrawal?.token?.decimals) @deposit?.token?.symbol</MudTd>
         <MudTd DataLabel="Fee"></MudTd>
         break;
     case "OrderbookTrade":
-        <MudTd DataLabel="From Address">@AccountLinkHelper.CreateUserLink(orderBookTrade!.accountA!, ignoreUserIDForLink)</MudTd>
-        <MudTd DataLabel="To Address">@AccountLinkHelper.CreateUserLink(orderBookTrade!.accountB!, ignoreUserIDForLink)</MudTd>
+        <MudTd DataLabel="From Address">@LinkHelper.CreateUserLink(orderBookTrade!.accountA!, ignoreUserIDForLink)</MudTd>
+        <MudTd DataLabel="To Address">@LinkHelper.CreateUserLink(orderBookTrade!.accountB!, ignoreUserIDForLink)</MudTd>
         <MudTd DataLabel="Amount" Style="text-align:right" >@TokenAmountConverter.ToString(orderBookTrade!.fillBA, orderBookTrade!.tokenB!.decimals) @orderBookTrade.tokenB.symbol</MudTd>
         @if(orderBookTrade!.feeA > 0)
         {
@@ -30,14 +30,14 @@
         }
         break;
     case "Transfer":
-        <MudTd DataLabel="From Address">@AccountLinkHelper.CreateUserLink(transfer!.fromAccount!, ignoreUserIDForLink)</MudTd>
-        <MudTd DataLabel="To Address">@AccountLinkHelper.CreateUserLink(transfer!.toAccount!, ignoreUserIDForLink)</MudTd>
+        <MudTd DataLabel="From Address">@LinkHelper.CreateUserLink(transfer!.fromAccount!, ignoreUserIDForLink)</MudTd>
+        <MudTd DataLabel="To Address">@LinkHelper.CreateUserLink(transfer!.toAccount!, ignoreUserIDForLink)</MudTd>
         <MudTd DataLabel="Amount" Style="text-align:right" >@TokenAmountConverter.ToString(transfer!.amount!, transfer.token!.decimals) @transfer!.token!.symbol</MudTd>
         <MudTd DataLabel="Fee" Style="text-align:right" >@TokenAmountConverter.ToString(transfer!.fee!, transfer.feeToken!.decimals) @transfer!.feeToken!.symbol</MudTd>
         break;
     case "Swap":
-        <MudTd DataLabel="From Address">@AccountLinkHelper.CreateUserLink(swap!.account!, ignoreUserIDForLink)</MudTd>
-        <MudTd DataLabel="To Address">@AccountLinkHelper.CreateUserLink(swap!.pool!, ignoreUserIDForLink)</MudTd>
+        <MudTd DataLabel="From Address">@LinkHelper.CreateUserLink(swap!.account!, ignoreUserIDForLink)</MudTd>
+        <MudTd DataLabel="To Address">@LinkHelper.CreateUserLink(swap!.pool!, ignoreUserIDForLink)</MudTd>
         <MudTd DataLabel="Amount" Style="text-align:right" >@TokenAmountConverter.ToString(swap!.fillBA, swap.tokenB!.decimals) @swap.tokenB.symbol</MudTd>
         if (swap!.feeA > 0)
         {

--- a/Lexplorer/Components/TransferTransactionDetail.razor
+++ b/Lexplorer/Components/TransferTransactionDetail.razor
@@ -23,11 +23,11 @@
                             </tr>
                             <tr>
                                 <td>From</td>
-                                <td>@AccountLinkHelper.CreateUserLink(TransferDetails.fromAccount!, false)</td>
+                                <td>@LinkHelper.CreateUserLink(TransferDetails.fromAccount!, false)</td>
                             </tr>
                             <tr>
                                 <td>To</td>
-                                <td>@AccountLinkHelper.CreateUserLink(TransferDetails.toAccount!, false)</td>
+                                <td>@LinkHelper.CreateUserLink(TransferDetails.toAccount!, false)</td>
                             </tr>
                             <tr>
                                 <td>Amount</td>

--- a/Lexplorer/Helpers/LinkHelper.cs
+++ b/Lexplorer/Helpers/LinkHelper.cs
@@ -3,7 +3,7 @@
     using Microsoft.AspNetCore.Components;
     using Lexplorer.Models;
 
-    public class AccountLinkHelper
+    public class LinkHelper
     {
         public static MarkupString CreateUserLink(Account? account, string? ignoreId = null)
         {

--- a/Lexplorer/Helpers/LinkHelper.cs
+++ b/Lexplorer/Helpers/LinkHelper.cs
@@ -25,5 +25,24 @@
             }
             return new MarkupString(link);
         }
+
+        public static Tuple<string, string>? GetObjectLinkAddress(object linkedObject)
+        {
+            if (linkedObject is Account)
+                return new Tuple<string, string>($"account/{((Account)linkedObject).id}", ((Account)linkedObject).id ?? "");
+            else if (linkedObject is BlockDetail)
+                return new Tuple<string, string>($"blocks/{((BlockDetail)linkedObject).id}", ((BlockDetail)linkedObject).id ?? "");
+            else if (linkedObject is Transaction)
+            return new Tuple<string, string>($"transactions/{((Transaction)linkedObject).typeName}/{((Transaction)linkedObject).id}", 
+                ((Transaction)linkedObject).id ?? "");
+            else
+                return null;
+        }
+        public static MarkupString GetObjectLink(object linkedObject)
+        {
+            Tuple<string, string>? adr = GetObjectLinkAddress(linkedObject);
+            if (adr == null) return new MarkupString();
+            return new MarkupString($"<a Class=\"mud-theme-primary\" href=\"{adr.Item1}\">{adr.Item2}</a>");
+        }
     }
 }

--- a/Shared/Models/LoopringV3.cs
+++ b/Shared/Models/LoopringV3.cs
@@ -10,6 +10,8 @@ namespace Lexplorer.Models
 {
     public class BlockDetail
     {
+        [JsonProperty("__typename")]
+        public string? typeName { get; set; }
         public Int64 accountUpdateCount { get; set; }
         public Int64 addCount { get; set; }
         public Int64 ammUpdateCount { get; set; }

--- a/Shared/Services/LoopringGraphQLService.cs
+++ b/Shared/Services/LoopringGraphQLService.cs
@@ -39,6 +39,23 @@ namespace Lexplorer.Services
                 proxy(id: 0) {
                   blockCount
                   userCount
+                  transactionCount
+                  depositCount
+                  withdrawalCount
+                  transferCount
+                  addCount
+                  removeCount
+                  orderbookTradeCount
+                  swapCount
+                  accountUpdateCount
+                  ammUpdateCount
+                  signatureVerificationCount
+                  tradeNFTCount
+                  swapNFTCount
+                  withdrawalNFTCount
+                  transferNFTCount
+                  nftMintCount
+                  nftDataCount
                 }
                 blocks(
                   skip: $skip

--- a/Shared/Services/LoopringGraphQLService.cs
+++ b/Shared/Services/LoopringGraphQLService.cs
@@ -760,7 +760,7 @@ namespace Lexplorer.Services
             = new Dictionary<string, Type>
         {
                 { "accounts", typeof(Account) },
-                { "blocks", typeof(Block) },
+                { "blocks", typeof(BlockDetail) },
                 { "transactions", typeof(Transaction) }
         };
         public async Task<IList<object>?> Search(string searchTerm)

--- a/xUnitTests/LoopringGraphTests/TestPairs.cs
+++ b/xUnitTests/LoopringGraphTests/TestPairs.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Lexplorer.Services;
+
+namespace xUnitTests.LoopringGraphTests
+{
+    [Collection("LoopringGraphQL collection")]
+    public class TestPairs
+    {
+        GraphQLTestsFixture fixture;
+        LoopringGraphQLService service;
+
+        public TestPairs(GraphQLTestsFixture fixture)
+        {
+            this.fixture = fixture;
+            this.service = fixture!.LGS;
+        }
+
+        [Fact]
+        public async void GetPairs()
+        {
+            var pairs = await service.GetPairs(0, 10);
+            Assert.NotNull(pairs?.data);
+            Assert.NotEmpty(pairs!.data!.pairs);
+            Assert.Equal(10, pairs!.data!.pairs!.Count);
+        }
+    }
+}

--- a/xUnitTests/LoopringGraphTests/TestSearch.cs
+++ b/xUnitTests/LoopringGraphTests/TestSearch.cs
@@ -28,7 +28,7 @@ namespace xUnitTests.LoopringGraphTests
             Assert.NotNull(searchResult);
             Assert.Equal(2, searchResult!.Count);
             Assert.IsType<User>(searchResult[0]);
-            Assert.IsType<Block>(searchResult[1]);
+            Assert.IsType<BlockDetail>(searchResult[1]);
         }
 
         [Fact]

--- a/xUnitTests/LoopringGraphTests/TestSearch.cs
+++ b/xUnitTests/LoopringGraphTests/TestSearch.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Lexplorer.Services;
+using Lexplorer.Models;
+
+namespace xUnitTests.LoopringGraphTests
+{
+    [Collection("LoopringGraphQL collection")]
+    public class TestSearch
+    {
+        GraphQLTestsFixture fixture;
+        LoopringGraphQLService service;
+
+        public TestSearch(GraphQLTestsFixture fixture)
+        {
+            this.fixture = fixture;
+            this.service = fixture!.LGS;
+        }
+
+        [Fact]
+        public async void SearchAccountAndBlock()
+        {
+            var searchResult = await service.Search("17714");
+            Assert.NotNull(searchResult);
+            Assert.Equal(2, searchResult!.Count);
+            Assert.IsType<User>(searchResult[0]);
+            Assert.IsType<Block>(searchResult[1]);
+        }
+
+        [Fact]
+        public async void SearchTransaction()
+        {
+            var searchResult = await service.Search("17714-19");
+            Assert.NotNull(searchResult);
+            Assert.Equal(1, searchResult!.Count);
+            Assert.IsType<Add>(searchResult[0]);
+        }
+    }
+}


### PR DESCRIPTION
1. Implementing search (closing issue #46)
   1. only block, account and transaction IDs for now
   2. combined query for all, returning one list of object
   3. renamed, extended LinkHelper
2. Improvement homepage in general
   1. made it null safe with progress indicators while loading
   2. now using ? not ! as actually the former is null-safe, the latter will raise an exception
   3. proxy info no longer queried with transactions *and* blocks but just blocks
   5. better string formats for larger numbers
   6. Pairs: added percentage of daily volume compared to weekly volume