### PR TITLE
NFT improvements

### DIFF
--- a/Lexplorer/Pages/NFTDetail.razor
+++ b/Lexplorer/Pages/NFTDetail.razor
@@ -12,7 +12,7 @@
 
 <MudSimpleTable Dense="true" Striped="true" Bordered="true">
     <div class="mud-toolbar mud-toolbar-gutters mud-table-toolbar">
-        <MudText Typo="Typo.h6">NFT @(@nftMetadata?.name ?? nft?.nftID)</MudText>
+        <MudText Typo="Typo.h6">@(nftMetadata?.name ?? $"NFT {nft?.nftID}")</MudText>
     </div>
     <tbody>
         <tr>
@@ -124,16 +124,7 @@
             if (nft == null) return;
             StateHasChanged();
         }
-        if (nftMetadata == null)
-        {
-            string nftMetadataLinkCacheKey = $"nftMetadataLink-{nftId}";
-            string? nftMetadataLink = await AppCache.GetOrAddAsync(nftMetadataLinkCacheKey, async () => await EthereumService.GetMetadataLink(nft?.nftID));
-            if (String.IsNullOrEmpty(nftMetadataLink)) return;
 
-            string nftMetadataCacheKey = $"nftMetadata-{nftId}";
-            nftMetadata = await AppCache.GetOrAddAsync(nftMetadataCacheKey, async () => await NftMetadataService.GetMetadata(nftMetadataLink));
-            StateHasChanged();
-        }
         if (String.IsNullOrEmpty(pageNumber))
         {
             pageNumber = "1";
@@ -145,6 +136,19 @@
             DateTimeOffset.UtcNow.AddMinutes(10));
         isLoading = false;
         StateHasChanged();
+
+        //load the NFT metadata last - it might actually take the longest and other services are queried etc.
+        if (nftMetadata == null)
+        {
+            string nftMetadataLinkCacheKey = $"nftMetadataLink-{nftId}";
+            string? nftMetadataLink = await AppCache.GetOrAddAsync(nftMetadataLinkCacheKey, async () => await EthereumService.GetMetadataLink(nft?.nftID));
+            if (String.IsNullOrEmpty(nftMetadataLink)) return;
+
+            string nftMetadataCacheKey = $"nftMetadata-{nftMetadataLink}";
+            nftMetadata = await AppCache.GetOrAddAsync(nftMetadataCacheKey, async () => await NftMetadataService.GetMetadata(nftMetadataLink));
+            StateHasChanged();
+        }
+
     }
 
 }

--- a/Shared/Helpers/GraphQLFragments.cs
+++ b/Shared/Helpers/GraphQLFragments.cs
@@ -74,6 +74,7 @@
             minter {
               ...AccountFragment
             }
+            __typename
             nftID
             nftType
             token

--- a/Shared/Services/LoopringGraphQLService.cs
+++ b/Shared/Services/LoopringGraphQLService.cs
@@ -943,6 +943,10 @@ namespace Lexplorer.Services
                   ) {
                     id
                     __typename
+                    block {
+                        id
+                        timestamp
+                    }
                     ...TradeNFTFragment
                     ...SwapNFTFragment
                     ...WithdrawalNFTFragment

--- a/Shared/Services/NftMetadataService.cs
+++ b/Shared/Services/NftMetadataService.cs
@@ -42,6 +42,7 @@ namespace Lexplorer.Services
             var request = new RestRequest(URL);
             try
             {
+                request.Timeout = 1000; //we can't afford to wait forever here, 1s must be enough
                 var response = await _client.GetAsync(request);
                 return JsonConvert.DeserializeObject<NftMetadata>(response.Content!);
             }

--- a/xUnitTests/LoopringGraphTests/BaseLGTest.cs
+++ b/xUnitTests/LoopringGraphTests/BaseLGTest.cs
@@ -17,13 +17,13 @@ namespace xUnitTests.LoopringGraphTests
 
         public GraphQLTestsFixture()
         {
-            // Do "global" initialization here; Only called once.
             LGS = new LoopringGraphQLService();
         }
 
         public void Dispose()
         {
-            // Do "global" teardown here; Only called once.
+            LGS.Dispose();
+            GC.SuppressFinalize(this);
         }
     }
 

--- a/xUnitTests/NFTMetaDataTests/BaseNMDTests.cs
+++ b/xUnitTests/NFTMetaDataTests/BaseNMDTests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Lexplorer.Services;
+using Xunit;
+
+namespace xUnitTests.NFTMetaDataTests
+{
+    //shared context for several xUnit test classes
+    //https://xunit.net/docs/shared-context
+    public class NFTMetaDataTestsFixture : IDisposable
+    {
+        public NftMetadataService NMS { get; private set; }
+        public EthereumService EthS { get; private set; }
+
+        public NFTMetaDataTestsFixture()
+        {
+            NMS = new NftMetadataService();
+            EthS = new EthereumService();
+        }
+
+        public void Dispose()
+        {
+            NMS.Dispose();
+            GC.SuppressFinalize(this);
+        }
+    }
+
+    [CollectionDefinition("NFTMetaDataTests collection")]
+    public class LoopringGraphQLCollection : ICollectionFixture<NFTMetaDataTestsFixture>
+    {
+        // This class has no code, and is never created. Its purpose is simply
+        // to be the place to apply [CollectionDefinition] and all the
+        // ICollectionFixture<> interfaces.
+    }
+}
+

--- a/xUnitTests/NFTMetaDataTests/TestNFTMetaData.cs
+++ b/xUnitTests/NFTMetaDataTests/TestNFTMetaData.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Xunit;
+using Lexplorer.Services;
+
+namespace xUnitTests.NFTMetaDataTests
+{
+	[Collection("NFTMetaDataTests collection")]
+	public class TestNFTMetaData
+	{
+		readonly NFTMetaDataTestsFixture fixture;
+
+		public TestNFTMetaData(NFTMetaDataTestsFixture fixture)
+		{
+			this.fixture = fixture;
+		}
+
+		[Theory]
+		[InlineData("0x4baf35a6982a81402fbe5882a47a75add97a01cc69fc418b5fc545026751f08a")]
+		[InlineData("0x78cc3ebffd8628722aaf29681b45d6a342e4ae11520c1d507894cc0c86049075")]
+		//[InlineData("0x01346618000000000000000002386f26fc10000000000000000000000000028d")] //loophead #653
+		public async void TestGetMetadata(string nftID)
+        {
+			var link = await fixture.EthS.GetMetadataLink(nftID);
+			Assert.NotNull(link);
+
+			var meta = await fixture.NMS.GetMetadata(link!);
+			Assert.NotNull(meta);
+        }
+	}
+}
+

--- a/xUnitTests/xUnitTests.csproj
+++ b/xUnitTests/xUnitTests.csproj
@@ -24,6 +24,12 @@
     </PackageReference>
   </ItemGroup>
 
+  <ItemGroup>
+    <None Remove="NFTMetaDataTests\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="NFTMetaDataTests\" />
+  </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 
 </Project>


### PR DESCRIPTION
Most important is reducing the humongous 100s RestRequest timeout when retrieving NFT metadata as that fails quiet often.

For all else, see the separate compact commits.