### PR TITLE
Added NFTs to accounts page fixing #70

### DIFF
--- a/Lexplorer/Pages/Account.razor
+++ b/Lexplorer/Pages/Account.razor
@@ -18,7 +18,7 @@
     <tbody>
         <tr>
             <td>L1 Address</td>
-            <td>@account?.address</td>
+            <td><L1AccountLink address="@account?.address" shortenAddress="false"/></td>
         </tr>
         <tr>
             <td>Account Type</td>

--- a/Lexplorer/Pages/Account.razor
+++ b/Lexplorer/Pages/Account.razor
@@ -43,7 +43,7 @@
 
 <MudTabs>
     <MudTabPanel Text="Token balances">
-        <MudTable Dense="true" Striped="true" Bordered="true" Items="@account?.balances" Hover="true" Loading=@balancesLoadíng>
+        <MudTable Dense="true" Striped="true" Bordered="true" Items="@account?.balances" Hover="true" Loading=@balancesLoading>
             <HeaderContent>
                 <MudTh Style="text-align:right"><MudTableSortLabel SortBy="new Func<AccountTokenBalance, object>(x=>x.token!.name!)">Token</MudTableSortLabel></MudTh>
                 <MudTh><MudTableSortLabel SortBy="new Func<AccountTokenBalance, object>(x=>x.fBalance!)">Balance</MudTableSortLabel></MudTh>
@@ -161,7 +161,7 @@
         }
     }
 
-    public bool balancesLoadíng;
+    public bool balancesLoading;
     public bool isLoading = true;
     public readonly int pageSize = 25;
     public readonly int nftPageSize = 10;
@@ -185,12 +185,12 @@
         if (accountId == null) return;
         if (account == null)
         {
-            balancesLoadíng = true;
+            balancesLoading = true;
             account = await LoopringGraphQLService.GetAccount(accountId);
             if (account == null) return;
             StateHasChanged();
             account!.balances = await LoopringGraphQLService.GetAccountBalance(accountId);
-            balancesLoadíng = false;
+            balancesLoading = false;
             StateHasChanged();
         }
         if (String.IsNullOrEmpty(pageNumber))

--- a/Lexplorer/Pages/Account.razor
+++ b/Lexplorer/Pages/Account.razor
@@ -3,92 +3,125 @@
 @using Lexplorer.Helpers
 @using Lexplorer.Components
 @inject Lexplorer.Services.LoopringGraphQLService LoopringGraphQLService;
+@inject Lexplorer.Services.EthereumService EthereumService;
+@inject Lexplorer.Services.NftMetadataService NftMetadataService;
 @inject NavigationManager NavigationManager;
 @inject IDialogService DialogService;
 @inject IAppCache AppCache;
 
 <PageTitle>The Lexplorer - Account</PageTitle>
 
-        <MudSimpleTable Dense="true" Striped="true" Bordered="true">
-            <div class="mud-toolbar mud-toolbar-gutters mud-table-toolbar">
-                <MudText Typo="Typo.h6">@account?.typeName #@account?.id</MudText>
-            </div>
-            <tbody>
-                <tr>
-                    <td>L1 Address</td>
-                    <td>@account?.address</td>
-                </tr>
-                <tr>
-                    <td>Account Type</td>
-                    <td>@account?.typeName</td>
-                </tr>
-                <tr>
-                    <td>Created At (UTC)</td>
-                    <td>@account?.createdAtTransaction?.verifiedAt</td>
-                </tr>
+<MudSimpleTable Dense="true" Striped="true" Bordered="true">
+    <div class="mud-toolbar mud-toolbar-gutters mud-table-toolbar">
+        <MudText Typo="Typo.h6">@account?.typeName #@account?.id</MudText>
+    </div>
+    <tbody>
+        <tr>
+            <td>L1 Address</td>
+            <td>@account?.address</td>
+        </tr>
+        <tr>
+            <td>Account Type</td>
+            <td>@account?.typeName</td>
+        </tr>
+        <tr>
+            <td>Created At (UTC)</td>
+            <td>@account?.createdAtTransaction?.verifiedAt</td>
+        </tr>
         @if (account is User)
         {
-                <tr>
-                    <td>Public key</td>
-                    <td>0x@((account as User)!.publicKey)</td>
-                </tr>
-                
+            <tr>
+                <td>Public key</td>
+                <td>0x@((account as User)!.publicKey)</td>
+            </tr>
+
         }
-            </tbody>
-        </MudSimpleTable>
+    </tbody>
+</MudSimpleTable>
 
-        <br />
+<br />
 
+<MudTabs>
+    <MudTabPanel Text="Token balances">
         <MudTable Dense="true" Striped="true" Bordered="true" Items="@account?.balances" Hover="true" Loading=@balancesLoadíng>
-            <ToolBarContent>
-                <MudText Typo="Typo.h6">Token balances</MudText>
-            </ToolBarContent>
             <HeaderContent>
                 <MudTh Style="text-align:right"><MudTableSortLabel SortBy="new Func<AccountTokenBalance, object>(x=>x.token!.name!)">Token</MudTableSortLabel></MudTh>
                 <MudTh><MudTableSortLabel SortBy="new Func<AccountTokenBalance, object>(x=>x.fBalance!)">Balance</MudTableSortLabel></MudTh>
             </HeaderContent>
             <RowTemplate>
                 <MudTd Style="text-align:right" DataLabel="Token">@context.token!.name</MudTd>
-                <MudTd DataLabel="Balance">@TokenAmountConverter.ToString(context.balance, context.token!.decimals) @context.token.symbol</MudTd>                
+                <MudTd DataLabel="Balance">@TokenAmountConverter.ToString(context.balance, context.token!.decimals) @context.token.symbol</MudTd>
             </RowTemplate>
             <PagerContent>
-        @if (account?.balances?.Count > 10)
-        {
-                <MudTablePager InfoFormat="@("{first_item}-{last_item} of {all_items}")" HorizontalAlignment="HorizontalAlignment.Left"/>
-        }
+                @if (account?.balances?.Count > 10)
+                {
+                    <MudTablePager InfoFormat="@("{first_item}-{last_item} of {all_items}")" HorizontalAlignment="HorizontalAlignment.Left" />
+                }
             </PagerContent>
         </MudTable>
+    </MudTabPanel>
+    <MudTabPanel Text="NFTs">
+        @if (accountNFTSlots == null)
+        {
+            <MudText>No NFTs</MudText>
+        }
+        else
+        {
+            <MudGrid>
+                @foreach (var slot in accountNFTSlots)
+                    {
+                    var metaData = GetMetadata(slot.nft?.nftID);
+                    <MudItem xs="2">
+                        <MudCard>
+                            <MudCardHeader>
+                                <CardHeaderContent>
+                                    <MudText Typo="Typo.body1">@metaData?.name</MudText>
+                                    <MudText Typo="Typo.body2">@metaData?.description</MudText>
+                                    <MudText Typo="Typo.body2">Amount: @slot.balance.ToString("#,##0")</MudText>
+                                </CardHeaderContent>
+                                <CardHeaderActions>
+                                    <MudIconButton Icon="@Icons.Material.Filled.Link" Color="Color.Default" Link=@LinkHelper.GetObjectLinkAddress(slot.nft)?.Item1 />
+                                </CardHeaderActions>
+                            </MudCardHeader>
+                            <MudCardMedia Image="@metaData?.imageURL" Height="300" />
+                        </MudCard>
+                    </MudItem>
+                }
+            </MudGrid>
+        }
+    </MudTabPanel>
+</MudTabs>
 
-    <br />
+<br />
 
-    <MudTable Dense="true" Striped="true" Bordered="true" Items="@transactions" Hover="true" Loading=@isLoading>
-        <ToolBarContent>
-            <MudText Typo="Typo.h6">Transactions</MudText>
-            <MudSpacer/>
-            <MudIconButton Icon="@Icons.Filled.FirstPage" Disabled=@(gotoPage == 1) OnClick="@(() => gotoPage = 1)"/>
-            <MudIconButton Icon="@Icons.Filled.NavigateBefore" Disabled=@(gotoPage == 1) OnClick="@(() => gotoPage -= 1)"/>
-            <MudNumericField HideSpinButtons="true" @bind-Value="gotoPage" Label="Page" Variant="Variant.Outlined" Min="1" Margin="Margin.Dense" Class="flex-grow-0" Style="width:150px;"/>
-            <MudIconButton Icon="@Icons.Filled.NavigateNext" Disabled=@(transactions!.Count < pageSize) OnClick="@(() => gotoPage += 1)"/>
-            <MudSpacer/>
-            <MudIconButton Icon="@Icons.Filled.Download" OnClick="ShowCSVOptions"/>
-        </ToolBarContent>
-        <HeaderContent>
-            <MudTh>Tx Id</MudTh>
-            <MudTh>Type</MudTh>
-            <MudTh>From</MudTh>
-            <MudTh>To</MudTh>
-            <MudTh Style="text-align:right">Bought</MudTh>
-            <MudTh Style="text-align:right">Sold</MudTh>
-            <MudTh Style="text-align:right">Fee</MudTh>
-            <MudTh>Verified At (UTC)</MudTh>
-        </HeaderContent>
-        <RowTemplate>
-            <MudTd DataLabel="Transaction Id">@LinkHelper.GetObjectLink(context)</MudTd>
-            <MudTd DataLabel="Type">@context.typeName</MudTd>
-            <TransactionTableDetails TransactionData=@context ignoreUserIDForLink=@accountId/>
-            <MudTd DataLabel="Timestamp">@context.verifiedAt</MudTd>
-        </RowTemplate>
-    </MudTable>
+<MudTable Dense="true" Striped="true" Bordered="true" Items="@transactions" Hover="true" Loading=@isLoading>
+    <ToolBarContent>
+        <MudText Typo="Typo.h6">Transactions</MudText>
+        <MudSpacer />
+        <MudIconButton Icon="@Icons.Filled.FirstPage" Disabled=@(gotoPage == 1) OnClick="@(() => gotoPage = 1)" />
+        <MudIconButton Icon="@Icons.Filled.NavigateBefore" Disabled=@(gotoPage == 1) OnClick="@(() => gotoPage -= 1)" />
+        <MudNumericField HideSpinButtons="true" @bind-Value="gotoPage" Label="Page" Variant="Variant.Outlined" Min="1" Margin="Margin.Dense" Class="flex-grow-0" Style="width:150px;" />
+        <MudIconButton Icon="@Icons.Filled.NavigateNext" Disabled=@(transactions!.Count < pageSize) OnClick="@(() => gotoPage += 1)" />
+        <MudSpacer />
+        <MudIconButton Icon="@Icons.Filled.Download" OnClick="ShowCSVOptions" />
+    </ToolBarContent>
+    <HeaderContent>
+        <MudTh>Tx Id</MudTh>
+        <MudTh>Type</MudTh>
+        <MudTh>From</MudTh>
+        <MudTh>To</MudTh>
+        <MudTh Style="text-align:right">Bought</MudTh>
+        <MudTh Style="text-align:right">Sold</MudTh>
+        <MudTh Style="text-align:right">Fee</MudTh>
+        <MudTh>Verified At (UTC)</MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="Transaction Id">@LinkHelper.GetObjectLink(context)</MudTd>
+        <MudTd DataLabel="Type">@context.typeName</MudTd>
+        <TransactionTableDetails TransactionData=@context ignoreUserIDForLink=@accountId />
+        <MudTd DataLabel="Timestamp">@context.verifiedAt</MudTd>
+    </RowTemplate>
+</MudTable>
 
 @code {
     [Parameter]
@@ -98,24 +131,45 @@
     [SupplyParameterFromQuery]
     public string pageNumber { get; set; } = "1";
 
-    public int gotoPage { 
-        get 
-        { 
-            return Int32.Parse(pageNumber ?? "1"); 
-        } 
+    public int gotoPage
+    {
+        get
+        {
+            return Int32.Parse(pageNumber ?? "1");
+        }
         set
         {
-            string URL = $"/account/{accountId}?pageNumber={value}";
-            NavigationManager.NavigateTo(URL);            
+            string URL = $"/account/{accountId}?pageNumber={value}&nftPageNumber={nftPageNumber}";
+            NavigationManager.NavigateTo(URL);
+        }
+    }
+
+    [Parameter]
+    [SupplyParameterFromQuery]
+    public string nftPageNumber { get; set; } = "1";
+
+    public int gotoNFTPage
+    {
+        get
+        {
+            return Int32.Parse(nftPageNumber ?? "1");
+        }
+        set
+        {
+            string URL = $"/account/{accountId}?pageNumber={pageNumber}&nftPageNumber={value}";
+            NavigationManager.NavigateTo(URL);
         }
     }
 
     public bool balancesLoadíng;
     public bool isLoading = true;
     public readonly int pageSize = 25;
+    public readonly int nftPageSize = 10;
 
     private Lexplorer.Models.Account? account { get; set; }
     private IList<Lexplorer.Models.Transaction>? transactions { get; set; } = new List<Transaction>();
+    private IList<AccountNFTSlot>? accountNFTSlots { get; set; }
+    private Dictionary<string, NftMetadata> NFTdata { get; set; } = new Dictionary<string, NftMetadata>();
 
     protected override async Task OnParametersSetAsync()
     {
@@ -145,11 +199,46 @@
         }
 
         string transactionCacheKey = $"account{accountId}-transactions-page{pageNumber}";
-        transactions = await AppCache.GetOrAddAsync(transactionCacheKey, 
-            async () => await LoopringGraphQLService.GetAccountTransactions((gotoPage - 1) * pageSize, pageSize, accountId), 
+        transactions = await AppCache.GetOrAddAsync(transactionCacheKey,
+            async () => await LoopringGraphQLService.GetAccountTransactions((gotoPage - 1) * pageSize, pageSize, accountId),
             DateTimeOffset.UtcNow.AddMinutes(10));
+        StateHasChanged();
+
+        string nftCacheKey = $"account{accountId}-nftSlots-page{pageNumber}";
+        accountNFTSlots = await AppCache.GetOrAddAsync(nftCacheKey,
+            async () => await LoopringGraphQLService.GetAccountNFTs((gotoNFTPage - 1) * nftPageSize, nftPageSize, accountId),
+            DateTimeOffset.UtcNow.AddMinutes(10));
+        NFTdata = new Dictionary<string, NftMetadata>();
+        if (accountNFTSlots != null)
+        {
+            StateHasChanged();
+            foreach (var slot in accountNFTSlots!)
+            {
+                string nftMetadataLinkCacheKey = $"nftMetadataLink-{slot.nft!.nftID}";
+                string? nftMetadataLink = await AppCache.GetOrAddAsync(nftMetadataLinkCacheKey,
+                    async () => await EthereumService.GetMetadataLink(slot.nft?.nftID, slot.nft?.token, slot.nft?.nftType));
+                if (String.IsNullOrEmpty(nftMetadataLink)) continue;
+
+                string nftMetadataCacheKey = $"nftMetadata-{nftMetadataLink}";
+                var nftMetadata = await AppCache.GetOrAddAsync(nftMetadataCacheKey, async () => await NftMetadataService.GetMetadata(nftMetadataLink));
+                if (nftMetadata == null) continue;
+
+                NFTdata.Add(slot.nft!.nftID!, nftMetadata);
+                StateHasChanged();
+            }
+        }
         isLoading = false;
         StateHasChanged();
+    }
+
+    private NftMetadata? GetMetadata(string? nftID)
+    {
+        NftMetadata? data = null;
+        if (nftID != null)
+        {
+            NFTdata.TryGetValue(nftID, out data);
+        }
+        return data;
     }
 
     private void ShowCSVOptions()

--- a/Lexplorer/Pages/Account.razor
+++ b/Lexplorer/Pages/Account.razor
@@ -68,6 +68,14 @@
         else
         {
             <MudGrid>
+                <MudItem xs="12" Class="d-flex justify-center">
+                    <MudToolBar>
+                        <MudIconButton Icon="@Icons.Filled.FirstPage" Disabled=@(gotoNFTPage == 1) OnClick="@(() => gotoNFTPage = 1)" />
+                        <MudIconButton Icon="@Icons.Filled.NavigateBefore" Disabled=@(gotoNFTPage == 1) OnClick="@(() => gotoNFTPage -= 1)" />
+                        <MudNumericField HideSpinButtons="true" @bind-Value="gotoNFTPage" Label="Page" Variant="Variant.Outlined" Min="1" Margin="Margin.Dense" Class="flex-grow-0" Style="width:150px;" />
+                        <MudIconButton Icon="@Icons.Filled.NavigateNext" Disabled=@(accountNFTSlots?.Count < nftPageSize) OnClick="@(() => gotoNFTPage += 1)" />
+                    </MudToolBar>
+                </MudItem>
                 @foreach (var slot in accountNFTSlots)
                     {
                     var metaData = GetMetadata(slot.nft?.nftID);
@@ -77,7 +85,7 @@
                                 <CardHeaderContent>
                                     <MudText Typo="Typo.body1">@metaData?.name</MudText>
                                     <MudText Typo="Typo.body2">@metaData?.description</MudText>
-                                    <MudText Typo="Typo.body2">Amount: @slot.balance.ToString("#,##0")</MudText>
+                                    <MudText Typo="Typo.body2">Balance: @slot.balance.ToString("#,##0")</MudText>
                                 </CardHeaderContent>
                                 <CardHeaderActions>
                                     <MudIconButton Icon="@Icons.Material.Filled.Link" Color="Color.Default" Link=@LinkHelper.GetObjectLinkAddress(slot.nft)?.Item1 />
@@ -135,7 +143,7 @@
     {
         get
         {
-            return Int32.Parse(pageNumber ?? "1");
+            return Int32.TryParse(pageNumber, out int np) ? np : 1;
         }
         set
         {
@@ -152,7 +160,7 @@
     {
         get
         {
-            return Int32.Parse(nftPageNumber ?? "1");
+            return Int32.TryParse(nftPageNumber, out int np) ? np : 1;
         }
         set
         {
@@ -164,7 +172,7 @@
     public bool balancesLoading;
     public bool isLoading = true;
     public readonly int pageSize = 25;
-    public readonly int nftPageSize = 10;
+    public readonly int nftPageSize = 12; //6 per row
 
     private Lexplorer.Models.Account? account { get; set; }
     private IList<Lexplorer.Models.Transaction>? transactions { get; set; } = new List<Transaction>();
@@ -179,7 +187,9 @@
         {
             account = null;
             transactions = new List<Transaction>();
+            accountNFTSlots = null;
             pageNumber = "1";
+            nftPageNumber = "1";
             StateHasChanged();
         }
         if (accountId == null) return;
@@ -204,7 +214,7 @@
             DateTimeOffset.UtcNow.AddMinutes(10));
         StateHasChanged();
 
-        string nftCacheKey = $"account{accountId}-nftSlots-page{pageNumber}";
+        string nftCacheKey = $"account{accountId}-nftSlots-page{nftPageNumber}";
         accountNFTSlots = await AppCache.GetOrAddAsync(nftCacheKey,
             async () => await LoopringGraphQLService.GetAccountNFTs((gotoNFTPage - 1) * nftPageSize, nftPageSize, accountId),
             DateTimeOffset.UtcNow.AddMinutes(10));

--- a/Shared/Models/LoopringV3.cs
+++ b/Shared/Models/LoopringV3.cs
@@ -321,6 +321,7 @@ namespace Lexplorer.Models
         public Transaction? createdAtTransaction { get; set; }
         public Transaction? lastUpdatedAtTransaction { get; set; }
         public List<Transaction>? transactions { get; set; }
+        public NonFungibleToken? nft { get; set; }
     }
 
     public class TransactionNFT : Transaction

--- a/xUnitTests/LoopringGraphTests/TestAccount.cs
+++ b/xUnitTests/LoopringGraphTests/TestAccount.cs
@@ -40,5 +40,16 @@ namespace xUnitTests.LoopringGraphTests
 
             Assert.Null(balances![0].account);
         }
+
+        [Fact]
+        public async void GetAccountNFTSlots()
+        {
+            IList<AccountNFTSlot>? slots = await service.GetAccountNFTs(0, 10, "32933");
+            Assert.NotEmpty(slots);
+            foreach (var slot in slots!)
+            {
+                Assert.NotNull(slot.nft);
+            }
+        }
     }
 }


### PR DESCRIPTION
Added tabs to switch between balances and NFTs. 
Separate page number for NFTs.

Using that you can see some quite surprising things, e.g. with account 32933. Seems some LH are not as unique as others? Strangely enough, the official explorer does not shown these NFTs, but the graph certainly delivers these. You can also see that some have been minted several times, so it all makes sense - but yet they're hidden on the official accounts page.