### PR TITLE
added video support

### DIFF
--- a/Lexplorer/Pages/NFTDetail.razor
+++ b/Lexplorer/Pages/NFTDetail.razor
@@ -40,7 +40,19 @@
             <td><L1AccountLink address="@nft?.token" shortenAddress="false" /></td>
         </tr>
         <tr>
-            <td colspan="2"><img src="@nftMetadata?.imageURL" Width="512" Height="512" /></td>
+            <td colspan="2">
+                @if(!String.IsNullOrEmpty(nftMetadata?.animationURL) && nftMetadata?.animationURL != nftMetadata?.imageURL) //Only show if animation url is not the same as the image url and is not empty
+                {
+                    <video width="512" height="512" controls>
+                      <source src="@nftMetadata?.animationURL" >
+                    Your browser does not support the video tag.
+                    </video>
+                }
+                else //Does not have video
+                {
+                    <img src="@nftMetadata?.imageURL" Width="512" Height="512" />
+                }
+            </td>
         </tr>
     </tbody>
 </MudSimpleTable>

--- a/Shared/Models/NftMetadata.cs
+++ b/Shared/Models/NftMetadata.cs
@@ -19,5 +19,17 @@ namespace Lexplorer.Models
         }
         public string? name { get; set; }
         public int royalty_percentage { get; set; }
+
+        public string? animation_url { get; set; }
+
+        public string? animationURL
+        {
+            get
+            {
+                if (animation_url == null) return null;
+                //remove the ipfs:// when concatenating with mypinata URL
+                return animation_url.StartsWith("ipfs://") ? string.Concat("https://fudgey.mypinata.cloud/ipfs/", animation_url.Remove(0, 7)) : animation_url;
+            }
+        }
     }
 }


### PR DESCRIPTION
this adds video support for nfts that define an animation_url in their metadata.json, nft with video example i used was 18497-5

On official explorer:
https://explorer.loopring.io/nft/0xc2bb4b516839df106fc4df8be868da5487638db9-0-0x27fa15862d7ebb1b8c8998a08b3405e12dc612ce-0x4de8f2002b80be98ccab8746c6569850a36b9f5de85b2900f846fa6134bfc8b7-10

if the animation url and image url are the same it will only display the image, otherwise if the animation url is not null and differs it will show the video.

