### PR TITLE
fix for null metadata error on some nfts

### DIFF
--- a/Lexplorer/Pages/NFTDetail.razor
+++ b/Lexplorer/Pages/NFTDetail.razor
@@ -182,7 +182,7 @@
             string nftMetadataCacheKey = $"nftMetadata-{nftMetadataLink}";
             nftMetadata = await AppCache.GetOrAddAsync(nftMetadataCacheKey, async () => await NftMetadataService.GetMetadata(nftMetadataLink));
             string nftMetadataContentTypeCacheKey = $"nftMetadata-contentType-{nftMetadataLink}";
-            if(!String.IsNullOrEmpty(nftMetadata!.animation_url))
+            if(nftMetadata != null && !String.IsNullOrEmpty(nftMetadata!.animation_url))
             {
                 nftMetadata!.contentType = await AppCache.GetOrAddAsync(nftMetadataContentTypeCacheKey, async () => 
                 await NftMetadataService.GetContentTypeFromURL(nftMetadata!.animation_url!.StartsWith("ipfs://") ? nftMetadata!.animation_url.Remove(0,7):nftMetadata!.animation_url));


### PR DESCRIPTION
i found a little issue where somehow there is no metadata.json file for some nfts and it would throw a null reference exception when trying to get the content type. example nft tx-id [17895-113](https://lexplorer.io/nfts/0x1a3d0d183675491f3ac6ed53526013681290690c-0-0x5e6f93906fda5e308def4fcacea5a30d140e7166-0x70c85ec58c4aeba21bd4fb00799f8b1313a32a1e8e4784e37ad6d030dbe2eda5-0). im thinking the nft data was unpinned from pinata for this to happen.

this fix just adds an extra check to make sure the nft metadata is not null

heres what the same nft looks like on the official explorer
https://explorer.loopring.io/nft/0x1a3d0d183675491f3ac6ed53526013681290690c-0-0x5e6f93906fda5e308def4fcacea5a30d140e7166-0x70c85ec58c4aeba21bd4fb00799f8b1313a32a1e8e4784e37ad6d030dbe2eda5-0