### PR TITLE
add html animation in url support

### DIFF
--- a/Lexplorer/Components/NFTContent.razor
+++ b/Lexplorer/Components/NFTContent.razor
@@ -35,6 +35,10 @@ else if (hasAnimationContent("model"))
     <model-viewer bounds="tight" enable-pan autoplay src="@nftMetadata?.animationURL" ar ar-modes="webxr scene-viewer quick-look"
                   camera-controls environment-image="neutral" poster="@nftMetadata?.imageURL" shadow-intensity="1"/>
 }
+else if(hasAnimationContent("html"))
+{
+    <iframe allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" frameborder="0" height="100%" sandbox="allow-scripts" src="@nftMetadata?.animationURL" width="100%" style="min-height: 680px;"></iframe>
+}
 
 
 @code {

--- a/Lexplorer/Components/NFTContent.razor
+++ b/Lexplorer/Components/NFTContent.razor
@@ -37,7 +37,7 @@ else if (hasAnimationContent("model"))
 }
 else if(hasAnimationContent("html"))
 {
-    <iframe allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" frameborder="0" height="100%" sandbox="allow-scripts" src="@nftMetadata?.animationURL" width="100%" style="min-height: 512px;"></iframe>
+    <iframe allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" frameborder="0" height="100%" sandbox="allow-scripts" src="@nftMetadata?.animationURL" width="100%" style="min-height: @ToPx(height)"></iframe>
 }
 
 

--- a/Lexplorer/Components/NFTContent.razor
+++ b/Lexplorer/Components/NFTContent.razor
@@ -37,7 +37,7 @@ else if (hasAnimationContent("model"))
 }
 else if(hasAnimationContent("html"))
 {
-    <iframe allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" frameborder="0" height="100%" sandbox="allow-scripts" src="@nftMetadata?.animationURL" width="100%" style="min-height: 680px;"></iframe>
+    <iframe allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" frameborder="0" height="100%" sandbox="allow-scripts" src="@nftMetadata?.animationURL" width="100%" style="min-height: 512px;"></iframe>
 }
 
 

--- a/xUnitTests/NFTMetaDataTests/TestNFTMetaData.cs
+++ b/xUnitTests/NFTMetaDataTests/TestNFTMetaData.cs
@@ -83,6 +83,20 @@ namespace xUnitTests.NFTMetaDataTests
 			var contentType = await fixture.NMS.GetContentTypeFromURL(meta!.animation_url!.StartsWith("ipfs://") ? meta!.animation_url.Remove(0, 7) : meta!.animation_url);
 			Assert.Equal("model/gltf-binary", contentType);
 		}
+
+		[Theory]
+		[InlineData("0x574e9ca4605e4ebff1d4e9b204b16fe73f122f82c60da0186af3ded68bff9c10", EthereumService.CF_NFTTokenAddress, 0)]
+		public async void TestGetMetadataHtmlContentType(string nftID, string nftTokenAddress, int nftType)
+		{
+			var link = await fixture.EthS.GetMetadataLink(nftID, nftTokenAddress, nftType);
+			Assert.NotNull(link);
+
+			var meta = await fixture.NMS.GetMetadata(link!);
+			Assert.NotNull(meta);
+
+			var contentType = await fixture.NMS.GetContentTypeFromURL(meta!.animation_url!.StartsWith("ipfs://") ? meta!.animation_url.Remove(0, 7) : meta!.animation_url);
+			Assert.Equal("text/html", contentType);
+		}
 	}
 }
 


### PR DESCRIPTION
fix #88 . this adds html support in animation url via an iframe. security wise i copied the same attributes of the iframe that opensea uses, so i think they know what they are doing in terms of that. also added a unit test for the html content type. 

test nft id here: 0x574e9ca4605e4ebff1d4e9b204b16fe73f122f82c60da0186af3ded68bff9c10

i would ideally like to autosize the height of the iframe to match the height of the body in the iframe but i couldnt figure out that out for now. if 