### PR TITLE
fix for issues when searching ens with .ETH and nft ids that were in …

### DIFF
--- a/Lexplorer/Shared/MainLayout.razor
+++ b/Lexplorer/Shared/MainLayout.razor
@@ -86,7 +86,7 @@
         searching = true;
         searchResults = null;
         StateHasChanged();
-        if (searchTerm.Contains(".eth"))
+        if (searchTerm.ToLower().Contains(".eth"))
         {
             string? hexAddress = await EthereumService.GetEthAddressFromEns(searchTerm);
             if (String.IsNullOrEmpty(hexAddress))

--- a/Shared/Services/LoopringGraphQLService.cs
+++ b/Shared/Services/LoopringGraphQLService.cs
@@ -884,7 +884,7 @@ namespace Lexplorer.Services
             //avoid query errors with search strings that cannot be converted to bytes
             //extra searchTermBytes is only filled if it matches strict RegEx, starting with 0x (added if missing)
             //and then any number of pairs "({2})+" of 0-9, a-f, A-F, end must be reached = $
-            string searchTermBytes = searchTerm.StartsWith("0x") ? searchTerm : "0x" + searchTerm;
+            string searchTermBytes = searchTerm.ToLower().StartsWith("0x") ? searchTerm.ToLower() : "0x" + searchTerm.ToLower();
             if (!Regex.Match(searchTermBytes, "0x([a-fA-F0-9]{2})+$").Success)
                 searchTermBytes = "";
             var request = new RestRequest();

--- a/xUnitTests/LoopringGraphTests/TestSearch.cs
+++ b/xUnitTests/LoopringGraphTests/TestSearch.cs
@@ -52,13 +52,14 @@ namespace xUnitTests.LoopringGraphTests
 
         [Theory]
         [InlineData("4baf35a6982a81402fbe5882a47a75add97a01cc69fc418b5fc545026751f08a")]
+        [InlineData("4BAF35A6982A81402FBE5882A47A75ADD97A01CC69FC418B5FC545026751F08A")]
         [InlineData("0x010a8144e644ace657426f10d35a2a3bee1d098e-0-0xdec45f94c65a79278b7a779a0f5e09a361672e5d-0x4baf35a6982a81402fbe5882a47a75add97a01cc69fc418b5fc545026751f08a-0")]
         public async void SearchNFT(string nftid)
         {
             var searchResult = await service.Search(nftid);
             Assert.NotEmpty(searchResult);
             Assert.IsType<NonFungibleToken>(searchResult![0]);
-            Assert.Contains(nftid, (searchResult![0] as NonFungibleToken)!.id);
+            Assert.Contains(nftid.ToLower(), (searchResult![0] as NonFungibleToken)!.id);
         }
     }
 }


### PR DESCRIPTION
…all uppercase.