### PR TITLE
fix for search when it contains only uppercase. 

### DIFF
--- a/.github/workflows/dev_lexplorer(dev).yml
+++ b/.github/workflows/dev_lexplorer(dev).yml
@@ -1,0 +1,57 @@
+# Docs for the Azure Web Apps Deploy action: https://github.com/Azure/webapps-deploy
+# More GitHub Actions for Azure: https://github.com/Azure/actions
+
+name: Build and deploy ASP.Net Core app to Azure Web App - lexplorer
+
+on:
+  push:
+    branches:
+      - dev
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.x'
+          include-prerelease: true
+
+      - name: Build with dotnet
+        run: dotnet build --configuration Release
+
+      - name: dotnet publish
+        run: dotnet publish -c Release -o ${{env.DOTNET_ROOT}}/myapp
+
+      - name: Upload artifact for deployment job
+        uses: actions/upload-artifact@v2
+        with:
+          name: .net-app
+          path: ${{env.DOTNET_ROOT}}/myapp
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: 'dev'
+      url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
+
+    steps:
+      - name: Download artifact from build job
+        uses: actions/download-artifact@v2
+        with:
+          name: .net-app
+
+      - name: Deploy to Azure Web App
+        id: deploy-to-webapp
+        uses: azure/webapps-deploy@v2
+        with:
+          app-name: 'lexplorer'
+          slot-name: 'dev'
+          publish-profile: ${{ secrets.AZUREAPPSERVICE_PUBLISHPROFILE_350B1FAAF33547B084E4314B18644F8F }}
+          package: .

--- a/Lexplorer/Shared/MainLayout.razor
+++ b/Lexplorer/Shared/MainLayout.razor
@@ -86,7 +86,7 @@
         searching = true;
         searchResults = null;
         StateHasChanged();
-        if (searchTerm.ToLower().Contains(".eth"))
+        if (searchTerm.Contains(".eth", StringComparison.InvariantCultureIgnoreCase))
         {
             string? hexAddress = await EthereumService.GetEthAddressFromEns(searchTerm);
             if (String.IsNullOrEmpty(hexAddress))

--- a/Shared/Services/LoopringGraphQLService.cs
+++ b/Shared/Services/LoopringGraphQLService.cs
@@ -884,8 +884,8 @@ namespace Lexplorer.Services
             //avoid query errors with search strings that cannot be converted to bytes
             //extra searchTermBytes is only filled if it matches strict RegEx, starting with 0x (added if missing)
             //and then any number of pairs "({2})+" of 0-9, a-f, A-F, end must be reached = $
-            string searchTermBytes = searchTerm.ToLower().StartsWith("0x") ? searchTerm.ToLower() : "0x" + searchTerm.ToLower();
-            if (!Regex.Match(searchTermBytes, "0x([a-fA-F0-9]{2})+$").Success)
+            string searchTermBytes = (searchTerm.StartsWith("0x", StringComparison.InvariantCultureIgnoreCase) ? searchTerm : "0x" + searchTerm).ToLower();
+            if (!Regex.Match(searchTermBytes, "0x([a-f0-9]{2})+$").Success)
                 searchTermBytes = "";
             var request = new RestRequest();
             request.AddHeader("Content-Type", "application/json");

--- a/xUnitTests/LoopringGraphTests/TestSearch.cs
+++ b/xUnitTests/LoopringGraphTests/TestSearch.cs
@@ -59,7 +59,7 @@ namespace xUnitTests.LoopringGraphTests
             var searchResult = await service.Search(nftid);
             Assert.NotEmpty(searchResult);
             Assert.IsType<NonFungibleToken>(searchResult![0]);
-            Assert.Contains(nftid.ToLower(), (searchResult![0] as NonFungibleToken)!.id);
+            Assert.Contains(nftid, (searchResult![0] as NonFungibleToken)!.id, StringComparison.InvariantCultureIgnoreCase);
         }
     }
 }


### PR DESCRIPTION
if searching by nft id that was all uppercase it wouldn't return anything in the results. similar issue when checking for ens, i've just made the conditional to lower so it matches the .eth portion. i didn't realise in azure that i have an additional deployment slot so ive set it up to deploy a development site at https://lexplorer-dev.azurewebsites.net on push/merge to this branch.

going forward should this be the main branch we develop on then? if we are happy with the changes on the development site we merge this branch into master/production?