### PR TITLE
Add cancellation token support

### DIFF
--- a/Lexplorer/Pages/Account.razor
+++ b/Lexplorer/Pages/Account.razor
@@ -62,7 +62,7 @@
         </MudTable>
     </MudTabPanel>
     <MudTabPanel Text="NFTs">
-        @if (accountNFTSlots == null)
+        @if ((accountNFTSlots?.Count ?? 0) > 0)
         {
             <MudText>No NFTs</MudText>
         }
@@ -77,7 +77,7 @@
                         <MudIconButton Icon="@Icons.Filled.NavigateNext" Disabled=@(accountNFTSlots?.Count < nftPageSize) OnClick="@(() => gotoNFTPage += 1)" />
                     </MudToolBar>
                 </MudItem>
-                @foreach (var slot in accountNFTSlots)
+                @foreach (var slot in accountNFTSlots!)
                 {
                     var metaData = GetMetadata(slot.nft?.id);
                     <MudItem xs="2">

--- a/Lexplorer/Pages/Account.razor
+++ b/Lexplorer/Pages/Account.razor
@@ -8,6 +8,7 @@
 @inject NavigationManager NavigationManager;
 @inject IDialogService DialogService;
 @inject IAppCache AppCache;
+@implements System.IDisposable
 
 <PageTitle>The Lexplorer - Account</PageTitle>
 
@@ -18,7 +19,7 @@
     <tbody>
         <tr>
             <td>L1 Address</td>
-            <td><L1AccountLink address="@account?.address" shortenAddress="false"/></td>
+            <td><L1AccountLink address="@account?.address" shortenAddress="false" /></td>
         </tr>
         <tr>
             <td>Account Type</td>
@@ -77,7 +78,7 @@
                     </MudToolBar>
                 </MudItem>
                 @foreach (var slot in accountNFTSlots)
-                    {
+                {
                     var metaData = GetMetadata(slot.nft?.id);
                     <MudItem xs="2">
                         <MudCard>
@@ -178,67 +179,95 @@
     private IList<Lexplorer.Models.Transaction>? transactions { get; set; } = new List<Transaction>();
     private IList<AccountNFTSlot>? accountNFTSlots { get; set; }
     private Dictionary<string, NftMetadata> NFTdata { get; set; } = new Dictionary<string, NftMetadata>();
+    private CancellationTokenSource? cts;
+
+    public void Dispose()
+    {
+        cts?.Cancel();
+        cts?.Dispose();
+    }
 
     protected override async Task OnParametersSetAsync()
     {
-        isLoading = true;
-        //did the account change?
-        if (account != null && account.id != accountId)
-        {
-            account = null;
-            transactions = new List<Transaction>();
-            accountNFTSlots = null;
-            pageNumber = "1";
-            nftPageNumber = "1";
-            StateHasChanged();
-        }
-        if (accountId == null) return;
-        if (account == null)
-        {
-            balancesLoading = true;
-            account = await LoopringGraphQLService.GetAccount(accountId);
-            if (account == null) return;
-            StateHasChanged();
-            account!.balances = await LoopringGraphQLService.GetAccountBalance(accountId);
-            balancesLoading = false;
-            StateHasChanged();
-        }
-        if (String.IsNullOrEmpty(pageNumber))
-        {
-            pageNumber = "1";
-        }
+        //cancel any previous OnParametersSetAsync which might still be running
+        cts?.Cancel();
+        cts?.Dispose();
 
-        string transactionCacheKey = $"account{accountId}-transactions-page{pageNumber}";
-        transactions = await AppCache.GetOrAddAsync(transactionCacheKey,
-            async () => await LoopringGraphQLService.GetAccountTransactions((gotoPage - 1) * pageSize, pageSize, accountId),
-            DateTimeOffset.UtcNow.AddMinutes(10));
-        StateHasChanged();
-
-        string nftCacheKey = $"account{accountId}-nftSlots-page{nftPageNumber}";
-        accountNFTSlots = await AppCache.GetOrAddAsync(nftCacheKey,
-            async () => await LoopringGraphQLService.GetAccountNFTs((gotoNFTPage - 1) * nftPageSize, nftPageSize, accountId),
-            DateTimeOffset.UtcNow.AddMinutes(10));
-        NFTdata = new Dictionary<string, NftMetadata>();
-        if (accountNFTSlots != null)
+        //create a new cts for this call
+        cts = new CancellationTokenSource();
+        try
         {
-            StateHasChanged();
-            foreach (var slot in accountNFTSlots!)
+            CancellationTokenSource localCTS = cts;
+            isLoading = true;
+            //did the account change?
+            if (account != null && account.id != accountId)
             {
-                string nftMetadataLinkCacheKey = $"nftMetadataLink-{slot.nft!.nftID}";
-                string? nftMetadataLink = await AppCache.GetOrAddAsync(nftMetadataLinkCacheKey,
-                    async () => await EthereumService.GetMetadataLink(slot.nft?.nftID, slot.nft?.token, slot.nft?.nftType));
-                if (String.IsNullOrEmpty(nftMetadataLink)) continue;
-
-                string nftMetadataCacheKey = $"nftMetadata-{nftMetadataLink}";
-                var nftMetadata = await AppCache.GetOrAddAsync(nftMetadataCacheKey, async () => await NftMetadataService.GetMetadata(nftMetadataLink));
-                if (nftMetadata == null) continue;
-
-                NFTdata.Add(slot.nft!.id!, nftMetadata);
+                account = null;
+                transactions = new List<Transaction>();
+                accountNFTSlots = null;
+                pageNumber = "1";
+                nftPageNumber = "1";
                 StateHasChanged();
             }
+            if (accountId == null) return;
+            if (account == null)
+            {
+                balancesLoading = true;
+                account = await LoopringGraphQLService.GetAccount(accountId, localCTS.Token);
+                localCTS.Token.ThrowIfCancellationRequested();
+                if (account == null) return;
+                StateHasChanged();
+                account!.balances = await LoopringGraphQLService.GetAccountBalance(accountId, localCTS.Token);
+                localCTS.Token.ThrowIfCancellationRequested();
+                balancesLoading = false;
+                StateHasChanged();
+            }
+            if (String.IsNullOrEmpty(pageNumber))
+            {
+                pageNumber = "1";
+            }
+
+            string transactionCacheKey = $"account{accountId}-transactions-page{pageNumber}";
+            transactions = await AppCache.GetOrAddAsync(transactionCacheKey,
+                async () => await LoopringGraphQLService.GetAccountTransactions((gotoPage - 1) * pageSize, pageSize, accountId, cancellationToken: localCTS.Token),
+                DateTimeOffset.UtcNow.AddMinutes(10));
+            localCTS.Token.ThrowIfCancellationRequested();
+            StateHasChanged();
+
+            string nftCacheKey = $"account{accountId}-nftSlots-page{nftPageNumber}";
+            accountNFTSlots = await AppCache.GetOrAddAsync(nftCacheKey,
+                async () => await LoopringGraphQLService.GetAccountNFTs((gotoNFTPage - 1) * nftPageSize, nftPageSize, accountId, localCTS.Token),
+                DateTimeOffset.UtcNow.AddMinutes(10));
+            localCTS.Token.ThrowIfCancellationRequested();
+
+            Dictionary<string, NftMetadata> localNFTdata = new Dictionary<string, NftMetadata>();
+            NFTdata = localNFTdata;
+
+            if (accountNFTSlots != null)
+            {
+                StateHasChanged();
+                foreach (var slot in accountNFTSlots!)
+                {
+                    string nftMetadataLinkCacheKey = $"nftMetadataLink-{slot.nft!.nftID}";
+                    string? nftMetadataLink = await AppCache.GetOrAddAsync(nftMetadataLinkCacheKey,
+                        async () => await EthereumService.GetMetadataLink(slot.nft?.nftID, slot.nft?.token, slot.nft?.nftType));
+                    if (String.IsNullOrEmpty(nftMetadataLink)) continue;
+
+                    string nftMetadataCacheKey = $"nftMetadata-{nftMetadataLink}";
+                    var nftMetadata = await AppCache.GetOrAddAsync(nftMetadataCacheKey, async () => await NftMetadataService.GetMetadata(nftMetadataLink, localCTS.Token));
+                    localCTS.Token.ThrowIfCancellationRequested();
+                    if (nftMetadata == null) continue;
+
+                    localNFTdata.Add(slot.nft!.id!, nftMetadata);
+                    StateHasChanged();
+                }
+            }
+            isLoading = false;
+            StateHasChanged();
         }
-        isLoading = false;
-        StateHasChanged();
+        catch (OperationCanceledException)
+        {
+        }
     }
 
     private NftMetadata? GetMetadata(string? nftID)

--- a/Shared/Services/LoopringGraphQLService.cs
+++ b/Shared/Services/LoopringGraphQLService.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using RestSharp.Serializers;
 using System.Globalization;
 using System.Text.RegularExpressions;
+using System.Threading;
 
 namespace Lexplorer.Services
 {
@@ -467,7 +468,7 @@ namespace Lexplorer.Services
                 return null;
             }
         }
-        public async Task<Account?> GetAccount(string accountId)
+        public async Task<Account?> GetAccount(string accountId, CancellationToken cancellationToken = default)
         {
             var accountQuery = @"
             query account(
@@ -497,7 +498,7 @@ namespace Lexplorer.Services
             });
             try
             {
-                var response = await _client.PostAsync(request);
+                var response = await _client.PostAsync(request, cancellationToken);
                 JObject jresponse = JObject.Parse(response.Content!);
                 JToken result = jresponse["data"]!["account"]!;
                 return result.ToObject<Account>()!;
@@ -509,7 +510,7 @@ namespace Lexplorer.Services
             }
 
         }
-        public async Task<List<AccountTokenBalance>?> GetAccountBalance(string accountId)
+        public async Task<List<AccountTokenBalance>?> GetAccountBalance(string accountId, CancellationToken cancellationToken = default)
         {
             var balanceQuery = @"
             query accountBalances(
@@ -542,7 +543,7 @@ namespace Lexplorer.Services
                     accountId = Int32.Parse(accountId)
                 }
             });
-            var response = await _client.PostAsync(request);
+            var response = await _client.PostAsync(request, cancellationToken);
             try
             {
                 JObject jresponse = JObject.Parse(response.Content!);
@@ -564,7 +565,7 @@ namespace Lexplorer.Services
         }
 
         public async Task<string?> GetAccountTransactionsResponse(int skip, int first, string accountId,
-            Double? firstBlockId = null, Double? lastBlockId = null)
+            Double? firstBlockId = null, Double? lastBlockId = null, CancellationToken cancellationToken = default)
         {
             var accountQuery = @"
             query accountTransactions(
@@ -662,7 +663,7 @@ namespace Lexplorer.Services
             request.AddStringBody(jObject.ToString(), ContentType.Json);
             try
             {
-                var response = await _client.PostAsync(request);
+                var response = await _client.PostAsync(request, cancellationToken);
                 return response.Content;
             }
             catch (Exception ex)
@@ -673,11 +674,11 @@ namespace Lexplorer.Services
         }
 
         public async Task<IList<Transaction>?> GetAccountTransactions(int skip, int first, string accountId,
-            Double? firstBlockId = null, Double? lastBlockId = null)
+            Double? firstBlockId = null, Double? lastBlockId = null, CancellationToken cancellationToken = default)
         {
             try
             {
-                string? response = await GetAccountTransactionsResponse(skip, first, accountId, firstBlockId, lastBlockId);
+                string? response = await GetAccountTransactionsResponse(skip, first, accountId, firstBlockId, lastBlockId, cancellationToken);
                 JObject jresponse = JObject.Parse(response!);
                 JToken? token = jresponse["data"]!["account"]!["transactions"];
                 return token!.ToObject<IList<Transaction>>();
@@ -689,7 +690,7 @@ namespace Lexplorer.Services
             }
         }
 
-        public async Task<IList<AccountNFTSlot>?> GetAccountNFTs(int skip, int first, string accountId)
+        public async Task<IList<AccountNFTSlot>?> GetAccountNFTs(int skip, int first, string accountId, CancellationToken cancellationToken = default)
         {
             var accountNFTQuery = @"
             query accountNFTSlotsQuery(
@@ -741,7 +742,7 @@ namespace Lexplorer.Services
             request.AddStringBody(jObject.ToString(), ContentType.Json);
             try
             {
-                var response = await _client.PostAsync(request);
+                var response = await _client.PostAsync(request, cancellationToken);
                 JObject jresponse = JObject.Parse(response.Content!);
                 JToken? token = jresponse["data"]!["accountNFTSlots"];
                 return token!.ToObject<IList<AccountNFTSlot>>();

--- a/Shared/Services/NftMetadataService.cs
+++ b/Shared/Services/NftMetadataService.cs
@@ -6,6 +6,7 @@ using RestSharp;
 using System.Diagnostics;
 using Lexplorer.Models;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace Lexplorer.Services
 {
@@ -26,24 +27,24 @@ namespace Lexplorer.Services
             GC.SuppressFinalize(this);
         }
 
-        public async Task<NftMetadata?> GetMetadata(string link)
+        public async Task<NftMetadata?> GetMetadata(string link, CancellationToken cancellationToken = default)
         {
             //there is a fallback for if the metadata fails on the first try because
             //loopring deployed two different contracts for the nfts so some
             //metadata.json needs to be referenced directly while others are in a folder in ipfs
-            NftMetadata? nmd = await GetMetadataFromURL(link);
+            NftMetadata? nmd = await GetMetadataFromURL(link, cancellationToken);
             if (nmd == null)
-                nmd = await GetMetadataFromURL(link + "/metadata.json");
+                nmd = await GetMetadataFromURL(link + "/metadata.json", cancellationToken);
             return nmd;
         }
 
-        private async Task<NftMetadata?> GetMetadataFromURL(string URL)
+        private async Task<NftMetadata?> GetMetadataFromURL(string URL, CancellationToken cancellationToken = default)
         {
             var request = new RestRequest(URL);
             try
             {
                 request.Timeout = 5000; //we can't afford to wait forever here, 5s must be enough
-                var response = await _client.GetAsync(request);   
+                var response = await _client.GetAsync(request, cancellationToken);
                 return JsonConvert.DeserializeObject<NftMetadata>(response.Content!);
             }
             catch (Exception e)
@@ -53,13 +54,13 @@ namespace Lexplorer.Services
             }
         }
 
-        public async Task<string> GetContentTypeFromURL(string link)
+        public async Task<string> GetContentTypeFromURL(string link, CancellationToken cancellationToken = default)
         {
             var request = new RestRequest(link, Method.Head);
             try
             {
                 request.Timeout = 5000; //we can't afford to wait forever here, 5s must be enough
-                var response = await _client.HeadAsync(request); //Send head request so we only get header not the content
+                var response = await _client.HeadAsync(request, cancellationToken); //Send head request so we only get header not the content
                 Dictionary<string, string> contentHeaders = new Dictionary<string, string>();
                 foreach(var item in response.ContentHeaders!)
                 {


### PR DESCRIPTION
This one was actually quite complex and it hopefully solves #87 

The commit message of the 2nd commit explains all the important details, which I copied here for easier reading:

* cts property on the page object, but initially null
* each call of OnParametersSetAsync cancels and disposes any existing cancellation token before creating a new one - this ensures that unfinished previous calls will cancel
* it stores the current cts in a local copy to avoid that it inadvertently uses the new cts of a future call
* surround the whole method and catch only OperationCanceledException!
* add a IDisposable implementation and cancel and dispose cts
* all of this still hadn't solved the duplicate NFTdata entries!
* similar to the localCTS above, we now have a localNFTData too
* it is used for the page property NFTdata too (so that state changes actually show up on the page) but only until a new call comes in and creates a new NFTdata!

If there's anything unclear, don't hesitate to ask!