### PR TITLE
Fixing #96: empty NFTSlots check and additional exception to be caught

### DIFF
--- a/Lexplorer/Helpers/LAppCacheExtension.cs
+++ b/Lexplorer/Helpers/LAppCacheExtension.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using LazyCache;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Lexplorer.Helpers
+{
+	public static class LAppCacheExtensions
+	{
+		public static async Task<T> GetOrAddAsyncNonNull<T>(this IAppCache cache, string key, Func<Task<T>> addItemFactory, DateTimeOffset expires)
+		{
+			if (cache == null)
+			{
+				throw new ArgumentNullException("cache");
+			}
+			T retValue = await cache.GetOrAddAsync(key, addItemFactory, new MemoryCacheEntryOptions
+			{
+				AbsoluteExpiration = expires
+			});
+			if (retValue == null)
+				cache.Remove(key);
+			return retValue;
+		}
+
+		public static async Task<T> GetOrAddAsyncNonNull<T>(this IAppCache cache, string key, Func<Task<T>> addItemFactory)
+		{
+			if (cache == null)
+			{
+				throw new ArgumentNullException("cache");
+			}
+			T retValue = await cache.GetOrAddAsync(key, addItemFactory);
+			if (retValue == null)
+				cache.Remove(key);
+			return retValue;
+		}
+	}
+}

--- a/Lexplorer/Pages/Account.razor
+++ b/Lexplorer/Pages/Account.razor
@@ -2,6 +2,7 @@
 @using Lexplorer.Models
 @using Lexplorer.Helpers
 @using Lexplorer.Components
+@using System.Diagnostics
 @inject Lexplorer.Services.LoopringGraphQLService LoopringGraphQLService;
 @inject Lexplorer.Services.EthereumService EthereumService;
 @inject Lexplorer.Services.NftMetadataService NftMetadataService;
@@ -62,7 +63,7 @@
         </MudTable>
     </MudTabPanel>
     <MudTabPanel Text="NFTs">
-        @if ((accountNFTSlots?.Count ?? 0) > 0)
+        @if ((accountNFTSlots?.Count ?? 0) < 1)
         {
             <MudText>No NFTs</MudText>
         }
@@ -267,6 +268,13 @@
         }
         catch (OperationCanceledException)
         {
+        }
+        catch (ObjectDisposedException)
+        { //occurs if the previous cts has already been disposed while an action is still running
+        }
+        catch (Exception e)
+        {
+            Trace.WriteLine(e.StackTrace + "\n" + e.Message);
         }
     }
 

--- a/Lexplorer/Pages/Account.razor
+++ b/Lexplorer/Pages/Account.razor
@@ -223,14 +223,14 @@
                 }
 
                 string transactionCacheKey = $"account{accountId}-transactions-page{pageNumber}";
-                transactions = await AppCache.GetOrAddAsync(transactionCacheKey,
+                transactions = await AppCache.GetOrAddAsyncNonNull(transactionCacheKey,
                     async () => await LoopringGraphQLService.GetAccountTransactions((gotoPage - 1) * pageSize, pageSize, accountId, cancellationToken: localCTS.Token),
                     DateTimeOffset.UtcNow.AddMinutes(10));
                 localCTS.Token.ThrowIfCancellationRequested();
                 StateHasChanged();
 
                 string nftCacheKey = $"account{accountId}-nftSlots-page{nftPageNumber}";
-                accountNFTSlots = await AppCache.GetOrAddAsync(nftCacheKey,
+                accountNFTSlots = await AppCache.GetOrAddAsyncNonNull(nftCacheKey,
                     async () => await LoopringGraphQLService.GetAccountNFTs((gotoNFTPage - 1) * nftPageSize, nftPageSize, accountId, localCTS.Token),
                     DateTimeOffset.UtcNow.AddMinutes(10));
                 localCTS.Token.ThrowIfCancellationRequested();
@@ -244,12 +244,15 @@
                     foreach (var slot in accountNFTSlots!)
                     {
                         string nftMetadataLinkCacheKey = $"nftMetadataLink-{slot.nft!.nftID}";
-                        string? nftMetadataLink = await AppCache.GetOrAddAsync(nftMetadataLinkCacheKey,
-                            async () => await EthereumService.GetMetadataLink(slot.nft?.nftID, slot.nft?.token, slot.nft?.nftType));
+                        string? nftMetadataLink = await AppCache.GetOrAddAsyncNonNull(nftMetadataLinkCacheKey,
+                            async () => await EthereumService.GetMetadataLink(slot.nft?.nftID, slot.nft?.token, slot.nft?.nftType),
+                            DateTimeOffset.UtcNow.AddHours(1));
                         if (String.IsNullOrEmpty(nftMetadataLink)) continue;
 
                         string nftMetadataCacheKey = $"nftMetadata-{nftMetadataLink}";
-                        var nftMetadata = await AppCache.GetOrAddAsync(nftMetadataCacheKey, async () => await NftMetadataService.GetMetadata(nftMetadataLink, localCTS.Token));
+                        var nftMetadata = await AppCache.GetOrAddAsyncNonNull(nftMetadataCacheKey,
+                            async () => await NftMetadataService.GetMetadata(nftMetadataLink, localCTS.Token),
+                            DateTimeOffset.UtcNow.AddHours(1));
                         localCTS.Token.ThrowIfCancellationRequested();
                         if (nftMetadata == null) continue;
 
@@ -292,4 +295,4 @@
 
         DialogService.Show<TransactionExportDialog>("Export", parameters, options);
     }
-    }
+}

--- a/Lexplorer/Pages/Account.razor
+++ b/Lexplorer/Pages/Account.razor
@@ -9,7 +9,6 @@
 @inject NavigationManager NavigationManager;
 @inject IDialogService DialogService;
 @inject IAppCache AppCache;
-@implements System.IDisposable
 
 <PageTitle>The Lexplorer - Account</PageTitle>
 
@@ -182,99 +181,95 @@
     private Dictionary<string, NftMetadata> NFTdata { get; set; } = new Dictionary<string, NftMetadata>();
     private CancellationTokenSource? cts;
 
-    public void Dispose()
-    {
-        cts?.Cancel();
-        cts?.Dispose();
-    }
-
     protected override async Task OnParametersSetAsync()
     {
         //cancel any previous OnParametersSetAsync which might still be running
         cts?.Cancel();
-        cts?.Dispose();
 
-        //create a new cts for this call
-        cts = new CancellationTokenSource();
-        try
+        using (CancellationTokenSource localCTS = new CancellationTokenSource())
         {
-            CancellationTokenSource localCTS = cts;
-            isLoading = true;
-            //did the account change?
-            if (account != null && account.id != accountId)
+            //give future calls a chance to cancel us; it is now safe to replace
+            //any previous value of cts, since we already cancelled it above
+            cts = localCTS;
+            try
             {
-                account = null;
-                transactions = new List<Transaction>();
-                accountNFTSlots = null;
-                pageNumber = "1";
-                nftPageNumber = "1";
-                StateHasChanged();
-            }
-            if (accountId == null) return;
-            if (account == null)
-            {
-                balancesLoading = true;
-                account = await LoopringGraphQLService.GetAccount(accountId, localCTS.Token);
-                localCTS.Token.ThrowIfCancellationRequested();
-                if (account == null) return;
-                StateHasChanged();
-                account!.balances = await LoopringGraphQLService.GetAccountBalance(accountId, localCTS.Token);
-                localCTS.Token.ThrowIfCancellationRequested();
-                balancesLoading = false;
-                StateHasChanged();
-            }
-            if (String.IsNullOrEmpty(pageNumber))
-            {
-                pageNumber = "1";
-            }
-
-            string transactionCacheKey = $"account{accountId}-transactions-page{pageNumber}";
-            transactions = await AppCache.GetOrAddAsync(transactionCacheKey,
-                async () => await LoopringGraphQLService.GetAccountTransactions((gotoPage - 1) * pageSize, pageSize, accountId, cancellationToken: localCTS.Token),
-                DateTimeOffset.UtcNow.AddMinutes(10));
-            localCTS.Token.ThrowIfCancellationRequested();
-            StateHasChanged();
-
-            string nftCacheKey = $"account{accountId}-nftSlots-page{nftPageNumber}";
-            accountNFTSlots = await AppCache.GetOrAddAsync(nftCacheKey,
-                async () => await LoopringGraphQLService.GetAccountNFTs((gotoNFTPage - 1) * nftPageSize, nftPageSize, accountId, localCTS.Token),
-                DateTimeOffset.UtcNow.AddMinutes(10));
-            localCTS.Token.ThrowIfCancellationRequested();
-
-            Dictionary<string, NftMetadata> localNFTdata = new Dictionary<string, NftMetadata>();
-            NFTdata = localNFTdata;
-
-            if (accountNFTSlots != null)
-            {
-                StateHasChanged();
-                foreach (var slot in accountNFTSlots!)
+                isLoading = true;
+                //did the account change?
+                if (account != null && account.id != accountId)
                 {
-                    string nftMetadataLinkCacheKey = $"nftMetadataLink-{slot.nft!.nftID}";
-                    string? nftMetadataLink = await AppCache.GetOrAddAsync(nftMetadataLinkCacheKey,
-                        async () => await EthereumService.GetMetadataLink(slot.nft?.nftID, slot.nft?.token, slot.nft?.nftType));
-                    if (String.IsNullOrEmpty(nftMetadataLink)) continue;
-
-                    string nftMetadataCacheKey = $"nftMetadata-{nftMetadataLink}";
-                    var nftMetadata = await AppCache.GetOrAddAsync(nftMetadataCacheKey, async () => await NftMetadataService.GetMetadata(nftMetadataLink, localCTS.Token));
-                    localCTS.Token.ThrowIfCancellationRequested();
-                    if (nftMetadata == null) continue;
-
-                    localNFTdata.Add(slot.nft!.id!, nftMetadata);
+                    account = null;
+                    transactions = new List<Transaction>();
+                    accountNFTSlots = null;
+                    pageNumber = "1";
+                    nftPageNumber = "1";
                     StateHasChanged();
                 }
+                if (accountId == null) return;
+                if (account == null)
+                {
+                    balancesLoading = true;
+                    account = await LoopringGraphQLService.GetAccount(accountId, localCTS.Token);
+                    localCTS.Token.ThrowIfCancellationRequested();
+                    if (account == null) return;
+                    StateHasChanged();
+                    account!.balances = await LoopringGraphQLService.GetAccountBalance(accountId, localCTS.Token);
+                    localCTS.Token.ThrowIfCancellationRequested();
+                    balancesLoading = false;
+                    StateHasChanged();
+                }
+                if (String.IsNullOrEmpty(pageNumber))
+                {
+                    pageNumber = "1";
+                }
+
+                string transactionCacheKey = $"account{accountId}-transactions-page{pageNumber}";
+                transactions = await AppCache.GetOrAddAsync(transactionCacheKey,
+                    async () => await LoopringGraphQLService.GetAccountTransactions((gotoPage - 1) * pageSize, pageSize, accountId, cancellationToken: localCTS.Token),
+                    DateTimeOffset.UtcNow.AddMinutes(10));
+                localCTS.Token.ThrowIfCancellationRequested();
+                StateHasChanged();
+
+                string nftCacheKey = $"account{accountId}-nftSlots-page{nftPageNumber}";
+                accountNFTSlots = await AppCache.GetOrAddAsync(nftCacheKey,
+                    async () => await LoopringGraphQLService.GetAccountNFTs((gotoNFTPage - 1) * nftPageSize, nftPageSize, accountId, localCTS.Token),
+                    DateTimeOffset.UtcNow.AddMinutes(10));
+                localCTS.Token.ThrowIfCancellationRequested();
+
+                Dictionary<string, NftMetadata> localNFTdata = new Dictionary<string, NftMetadata>();
+                NFTdata = localNFTdata;
+
+                if (accountNFTSlots != null)
+                {
+                    StateHasChanged();
+                    foreach (var slot in accountNFTSlots!)
+                    {
+                        string nftMetadataLinkCacheKey = $"nftMetadataLink-{slot.nft!.nftID}";
+                        string? nftMetadataLink = await AppCache.GetOrAddAsync(nftMetadataLinkCacheKey,
+                            async () => await EthereumService.GetMetadataLink(slot.nft?.nftID, slot.nft?.token, slot.nft?.nftType));
+                        if (String.IsNullOrEmpty(nftMetadataLink)) continue;
+
+                        string nftMetadataCacheKey = $"nftMetadata-{nftMetadataLink}";
+                        var nftMetadata = await AppCache.GetOrAddAsync(nftMetadataCacheKey, async () => await NftMetadataService.GetMetadata(nftMetadataLink, localCTS.Token));
+                        localCTS.Token.ThrowIfCancellationRequested();
+                        if (nftMetadata == null) continue;
+
+                        localNFTdata.Add(slot.nft!.id!, nftMetadata);
+                        StateHasChanged();
+                    }
+                }
+                isLoading = false;
+                StateHasChanged();
             }
-            isLoading = false;
-            StateHasChanged();
-        }
-        catch (OperationCanceledException)
-        {
-        }
-        catch (ObjectDisposedException)
-        { //occurs if the previous cts has already been disposed while an action is still running
-        }
-        catch (Exception e)
-        {
-            Trace.WriteLine(e.StackTrace + "\n" + e.Message);
+            catch (OperationCanceledException)
+            {
+            }
+            catch (Exception e)
+            {
+                Trace.WriteLine(e.StackTrace + "\n" + e.Message);
+            }
+            //now for cleanup, we must clear cts, but only if it is still our localCTS, which we're about to dispose
+            //otherwise a new call has already replaced cts with it's own localCTS
+            Interlocked.CompareExchange<CancellationTokenSource?>(ref cts, null, localCTS);
         }
     }
 
@@ -297,4 +292,4 @@
 
         DialogService.Show<TransactionExportDialog>("Export", parameters, options);
     }
-}
+    }

--- a/Lexplorer/Pages/NFTDetail.razor
+++ b/Lexplorer/Pages/NFTDetail.razor
@@ -130,7 +130,7 @@
         {
             nftMetadata = null;
             string nftCacheKey = $"nft-{nftId}";
-            nft = await AppCache.GetOrAddAsync(nftCacheKey, async () => await LoopringGraphQLService.GetNFT(nftId));
+            nft = await AppCache.GetOrAddAsyncNonNull(nftCacheKey, async () => await LoopringGraphQLService.GetNFT(nftId));
             if (nft == null) return;
             StateHasChanged();
         }
@@ -141,7 +141,7 @@
         }
 
         string nftTransactionCacheKey = $"nft{nftId}-transactions-page{pageNumber}";
-        transactions = await AppCache.GetOrAddAsync(nftTransactionCacheKey,
+        transactions = await AppCache.GetOrAddAsyncNonNull(nftTransactionCacheKey,
             async () => await LoopringGraphQLService.GetNFTTransactions((gotoPage - 1) * pageSize, pageSize, nftId),
             DateTimeOffset.UtcNow.AddMinutes(10));
         isLoading = false;
@@ -151,15 +151,15 @@
         if (nftMetadata == null)
         {
             string nftMetadataLinkCacheKey = $"nftMetadataLink-{nftId}";
-            string? nftMetadataLink = await AppCache.GetOrAddAsync(nftMetadataLinkCacheKey, async () => await EthereumService.GetMetadataLink(nft?.nftID, nft?.token, nft?.nftType));
+            string? nftMetadataLink = await AppCache.GetOrAddAsyncNonNull(nftMetadataLinkCacheKey, async () => await EthereumService.GetMetadataLink(nft?.nftID, nft?.token, nft?.nftType));
             if (String.IsNullOrEmpty(nftMetadataLink)) return;
 
             string nftMetadataCacheKey = $"nftMetadata-{nftMetadataLink}";
-            nftMetadata = await AppCache.GetOrAddAsync(nftMetadataCacheKey, async () => await NftMetadataService.GetMetadata(nftMetadataLink));
+            nftMetadata = await AppCache.GetOrAddAsyncNonNull(nftMetadataCacheKey, async () => await NftMetadataService.GetMetadata(nftMetadataLink));
             if (!String.IsNullOrEmpty(nftMetadata?.animation_url))
             {
                 string nftMetadataContentTypeCacheKey = $"nftMetadata-contentType-{nftMetadataLink}";
-                nftMetadata!.contentType = await AppCache.GetOrAddAsync(nftMetadataContentTypeCacheKey,
+                nftMetadata!.contentType = await AppCache.GetOrAddAsyncNonNull(nftMetadataContentTypeCacheKey,
                     async () => await NftMetadataService.GetContentTypeFromURL(nftMetadata.animationURL!));
             }
             StateHasChanged();


### PR DESCRIPTION
* check for empty NFTSlots was wrong
* luckily I found a way to avoid manual disposing
* now "using" the localCTS
* initially setting page cts to localCTS, so subsequent call will cancel us
* before using is finished, make an interlocked exchange for cts back to null, so it's not cancelling our already disposed cts with the next call
* also added a universal exception catch which writes other exceptions to the trace - ideally, at least under the dev environment, it should show the trace in the browser; had a quick look: search term to look for is "ErrorBoundary"