### PR TITLE
different mime types for 3d nfts when deployed and increase timeouts, support for arweave/non ipfs

### DIFF
--- a/Lexplorer/Components/NFTContent.razor
+++ b/Lexplorer/Components/NFTContent.razor
@@ -24,7 +24,7 @@ else if (hasAnimationContent("image"))
 {
     <img src="@nftMetadata?.animationURL" Width="@width" Height="@height" />
 }
-else if (hasAnimationContent("model"))
+else if (hasAnimationContent("model") || hasAnimationContent("octet-stream"))
 {
 <style>
         model-viewer {

--- a/Shared/Services/EthereumService.cs
+++ b/Shared/Services/EthereumService.cs
@@ -34,7 +34,14 @@ namespace Lexplorer.Services
                 var function = contract.GetFunction(functionName);
                 object[] parameters = new object[1] { tokenId! };
                 var uri = await function.CallAsync<string>(parameters);
-                return uri?.Remove(0, 7); //remove the ipfs portion
+                if (!String.IsNullOrEmpty(uri) && uri.Contains("ipfs://"))
+                {
+                    return uri?.Remove(0, 7);
+                }
+                else
+                {
+                    return uri;
+                }
             }
             catch (Exception e)
             {

--- a/Shared/Services/NftMetadataService.cs
+++ b/Shared/Services/NftMetadataService.cs
@@ -43,7 +43,7 @@ namespace Lexplorer.Services
             var request = new RestRequest(URL);
             try
             {
-                request.Timeout = 5000; //we can't afford to wait forever here, 5s must be enough
+                request.Timeout = 10000; //we can't afford to wait forever here, 10s must be enough
                 var response = await _client.GetAsync(request, cancellationToken);
                 return JsonConvert.DeserializeObject<NftMetadata>(response.Content!);
             }
@@ -59,7 +59,7 @@ namespace Lexplorer.Services
             var request = new RestRequest(link, Method.Head);
             try
             {
-                request.Timeout = 5000; //we can't afford to wait forever here, 5s must be enough
+                request.Timeout = 20000; //we can't afford to wait forever here, 20s must be enough
                 var response = await _client.HeadAsync(request, cancellationToken); //Send head request so we only get header not the content
                 Dictionary<string, string> contentHeaders = new Dictionary<string, string>();
                 foreach(var item in response.ContentHeaders!)

--- a/xUnitTests/NFTMetaDataTests/TestNFTMetaData.cs
+++ b/xUnitTests/NFTMetaDataTests/TestNFTMetaData.cs
@@ -83,7 +83,7 @@ namespace xUnitTests.NFTMetaDataTests
 			Assert.NotNull(meta);
 
 			var contentType = await fixture.NMS.GetContentTypeFromURL(meta!.animation_url!.StartsWith("ipfs://") ? meta!.animation_url.Remove(0, 7) : meta!.animation_url);
-			Assert.Equal("model/gltf-binary", contentType);
+			Assert.Equal("application/octet-stream", contentType);
 		}
 
 		[Theory]

--- a/xUnitTests/NFTMetaDataTests/TestNFTMetaData.cs
+++ b/xUnitTests/NFTMetaDataTests/TestNFTMetaData.cs
@@ -19,6 +19,8 @@ namespace xUnitTests.NFTMetaDataTests
 		[InlineData("0x78cc3ebffd8628722aaf29681b45d6a342e4ae11520c1d507894cc0c86049075", EthereumService.CF_NFTTokenAddress, 0)]
 		[InlineData("0x01346618000000000000000002386f26fc1000000000000000000000000003a1", "0x1cacc96e5f01e2849e6036f25531a9a064d2fb5f", 0)] //loophead #929
 		[InlineData("0x01346618000000000000000002386f26fc10000000000000000000000000028d", "0x1cacc96e5f01e2849e6036f25531a9a064d2fb5f", 0)] //loophead #653
+		[InlineData("0x0000000000000000000000000000000000000000000000000000000000000006", "0x6a7ab7711adcfe67141df82ae853787ca93a7797", 0)] //metadata on arweave
+
 		public async void TestGetMetadata(string nftID, string nftTokenAddress, int nftType)
         {
 			var link = await fixture.EthS.GetMetadataLink(nftID, nftTokenAddress, nftType);


### PR DESCRIPTION
Sorry i had to push to this dev branch directly to test the azure deployment because there was an issue with some 3d nfts like these ones [0x166a75cdae50f38ce4866c88e511765cc36b3c9361f4703d451657b29b90f3a7](https://lexplorer.io/nfts/0x13a7434ba28eee742f3cdbc06f392e826e296a01-0-0x90690b427331e1532dc528a0ed8ca249df68b88e-0x166a75cdae50f38ce4866c88e511765cc36b3c9361f4703d451657b29b90f3a7-10) / [0xf11780791dfef9ca79a07f046e98ef0efdebecfaa763b24eb61ccaaca3132d32](https://lexplorer.io/nfts/0x124be95eb2321386360adddaff38f980bae2d33b-0-0xd8e8c807e4b33abfde1eb514e798f700ca4e361b-0xf11780791dfef9ca79a07f046e98ef0efdebecfaa763b24eb61ccaaca3132d32-10) where the mime type was different locally to when deployed on azure. mime types for these ones seem to be "application/octet-stream" when checking via azure. not sure if its just my computer but the old unit test for 3d models was failing for me now so i had to update it to use application/octet-stream

there was also a bug for nfts that didnt return ipfs:// in the metadata for example for nfts created on arweave like this one https://lexplorer.io/nfts/0x6a7ab7711adcfe67141df82ae853787ca93a7797-0-0x6a7ab7711adcfe67141df82ae853787ca93a7797-0x0000000000000000000000000000000000000000000000000000000000000006-0  . now we only remove the ipfs:// if it actually contains it otherwise we use the regular url. as a result of this i had to increase the timeout for GetMetadataFromURL as Arweave/other blockchain platforms could be even slower than ipfs. i also increased the GetContentTypeFromURL timeout as my thinking is since we already know the metadata exists and we only use it on the drill down nft detail page/from search its okay to wait much longer.



