### PR TITLE
added traits to nft details page

### DIFF
--- a/Lexplorer/Pages/NFTDetail.razor
+++ b/Lexplorer/Pages/NFTDetail.razor
@@ -47,7 +47,7 @@
             <td>Animation URL</td>
             <td>@nftMetadata?.animation_url</td>
         </tr>
-        @if(nftMetadata?.attributes != null && nftMetadata?.attributes!.Count > 0)
+        @if(nftMetadata?.attributes?.Count > 0)
         {
             <tr>
                 <td>Traits</td>

--- a/Lexplorer/Pages/NFTDetail.razor
+++ b/Lexplorer/Pages/NFTDetail.razor
@@ -47,6 +47,18 @@
             <td>Animation URL</td>
             <td>@nftMetadata?.animation_url</td>
         </tr>
+        @if(nftMetadata?.attributes != null && nftMetadata?.attributes!.Count > 0)
+        {
+            <tr>
+                <td>Traits</td>
+                <td>
+                    @foreach(var trait in nftMetadata?.attributes!)
+                    {
+                        <p>@trait.trait_type:@trait.value</p>
+                    }
+                </td>
+            </tr>
+        }
         <tr>
             <td colspan="2">
                 <NFTContent nftMetadata="@nftMetadata" />

--- a/Shared/Models/NftMetadata.cs
+++ b/Shared/Models/NftMetadata.cs
@@ -33,5 +33,13 @@ namespace Lexplorer.Models
         }
 
         public string? contentType { get; set; }
+
+        public List<Trait>? attributes { get; set; }
+    }
+
+    public class Trait
+    {
+        public string? trait_type { get; set; }
+        public object? value { get; set; } //value can be either string or int
     }
 }

--- a/Shared/Models/NftMetadata.cs
+++ b/Shared/Models/NftMetadata.cs
@@ -34,10 +34,10 @@ namespace Lexplorer.Models
 
         public string? contentType { get; set; }
 
-        public List<Trait>? attributes { get; set; }
+        public List<NftAttribute>? attributes { get; set; }
     }
 
-    public class Trait
+    public class NftAttribute
     {
         public string? trait_type { get; set; }
         public object? value { get; set; } //value can be either string or int


### PR DESCRIPTION
this PR is to display traits on the nft details page if they have been defined in the metadata. example NFT ID: 0x34ba0414a5fe091fd624469b02fb9e77cc33dffd7f71e897c4c948498568056c    , this is one from the GME Marketplace. Another NFT from a popular collection on Discord, 0x5e6de510d95b30c17d33c2659d0ac571dcf6a0e5a1e83fc0788b9e1b23507360 


