### PR TITLE
Various NFT improvements

### DIFF
--- a/Lexplorer/Components/HomepageOverview.razor
+++ b/Lexplorer/Components/HomepageOverview.razor
@@ -196,20 +196,20 @@
     protected override async Task OnInitializedAsync()
     {
         string blockCacheKey = $"homepage-block";
-        blockData = await AppCache.GetOrAddAsync(blockCacheKey, async () => await LoopringGraphQLService.GetBlocks(0, 10), DateTimeOffset.UtcNow.AddMinutes(10));
+        blockData = await AppCache.GetOrAddAsyncNonNull(blockCacheKey, async () => await LoopringGraphQLService.GetBlocks(0, 10), DateTimeOffset.UtcNow.AddMinutes(10));
         CalculateAverageBlockTime();
         CalculateLastBlockSubmitted();
         StateHasChanged();
         string transactionCacheKey = $"homepage-transaction";
-        transactionData = await AppCache.GetOrAddAsync(transactionCacheKey, async () => await LoopringGraphQLService.GetTransactions(0, 10), DateTimeOffset.UtcNow.AddMinutes(10));
+        transactionData = await AppCache.GetOrAddAsyncNonNull(transactionCacheKey, async () => await LoopringGraphQLService.GetTransactions(0, 10), DateTimeOffset.UtcNow.AddMinutes(10));
         StateHasChanged();
         string pairsCacheKey = $"homepage-pairs";
-        pairsData = await AppCache.GetOrAddAsync(pairsCacheKey, async () => await LoopringGraphQLService.GetPairs(), DateTimeOffset.UtcNow.AddHours(1));
+        pairsData = await AppCache.GetOrAddAsyncNonNull(pairsCacheKey, async () => await LoopringGraphQLService.GetPairs(), DateTimeOffset.UtcNow.AddHours(1));
         int pairCount = 0;
         foreach(var pair in pairsData!.data!.pairs!)
         {
             string uniSwapTokenCache = $"homepage-uniswapToken-{pair!.token1!.address!}";
-            var uniswapToken = await AppCache.GetOrAddAsync(uniSwapTokenCache, async () => await UniswapGraphQLService.GetTokenPrice(pair!.token1!.address!), DateTimeOffset.UtcNow.AddHours(1));
+            var uniswapToken = await AppCache.GetOrAddAsyncNonNull(uniSwapTokenCache, async () => await UniswapGraphQLService.GetTokenPrice(pair!.token1!.address!), DateTimeOffset.UtcNow.AddHours(1));
             if(uniswapToken != null && pairCount == 0)
             {
                 uniswapTokens = new List<UniswapToken>();

--- a/Lexplorer/Pages/Account.razor
+++ b/Lexplorer/Pages/Account.razor
@@ -81,7 +81,7 @@
                 {
                     var metaData = GetMetadata(slot.nft?.id);
                     <MudItem xs="2">
-                        <MudCard>
+                        <MudCard Style="height:100%">
                             <MudCardHeader>
                                 <CardHeaderContent>
                                     <MudText Typo="Typo.body1">@metaData?.name</MudText>

--- a/Lexplorer/Pages/BlockDetails.razor
+++ b/Lexplorer/Pages/BlockDetails.razor
@@ -122,14 +122,14 @@ else
         string blockCacheKey = $"blockDetailOverview-{blockNumber}";
 
         isBlockLoading = true;
-        block = await AppCache.GetOrAddAsync(blockCacheKey, async () => await LoopringGraphQLService.GetBlockDetails(Int32.Parse(blockNumber)), DateTimeOffset.UtcNow.AddMinutes(5));
+        block = await AppCache.GetOrAddAsyncNonNull(blockCacheKey, async () => await LoopringGraphQLService.GetBlockDetails(Int32.Parse(blockNumber)), DateTimeOffset.UtcNow.AddMinutes(5));
         if (block == null) return;
         blockData = new List<BlockData>();
         blockData.Add(block.data!);
         isBlockLoading = false;
         isTransactionLoading = true;
         string transactionDatacacheKey = $"blockDetailTransactions-{blockNumber}-page{pageNumber}";
-        transactionData = await AppCache.GetOrAddAsync(transactionDatacacheKey, async () => await LoopringGraphQLService.GetTransactions(Int32.Parse(pageNumber) * 10, 10, blockNumber), DateTimeOffset.UtcNow.AddMinutes(5));
+        transactionData = await AppCache.GetOrAddAsyncNonNull(transactionDatacacheKey, async () => await LoopringGraphQLService.GetTransactions(Int32.Parse(pageNumber) * 10, 10, blockNumber), DateTimeOffset.UtcNow.AddMinutes(5));
         isTransactionLoading = false;
         StateHasChanged();
     }

--- a/Lexplorer/Pages/NFTDetail.razor
+++ b/Lexplorer/Pages/NFTDetail.razor
@@ -162,7 +162,7 @@
         //load the NFT metadata last - it might actually take the longest and other services are queried etc.
         if (nftMetadata == null)
         {
-            string nftMetadataLinkCacheKey = $"nftMetadataLink-{nftId}";
+            string nftMetadataLinkCacheKey = $"nftMetadataLink-{nft?.nftID}";
             string? nftMetadataLink = await AppCache.GetOrAddAsyncNonNull(nftMetadataLinkCacheKey, async () => await EthereumService.GetMetadataLink(nft?.nftID, nft?.token, nft?.nftType));
             if (String.IsNullOrEmpty(nftMetadataLink)) return;
 

--- a/Lexplorer/Pages/NFTDetail.razor
+++ b/Lexplorer/Pages/NFTDetail.razor
@@ -2,6 +2,7 @@
 @using Lexplorer.Components;
 @using Lexplorer.Helpers;
 @using Lexplorer.Models;
+@using System.Diagnostics
 @inject IAppCache AppCache;
 @inject NavigationManager NavigationManager;
 @inject Lexplorer.Services.LoopringGraphQLService LoopringGraphQLService;
@@ -136,57 +137,84 @@
         }
     }
 
+    private CancellationTokenSource? cts;
 
     protected override async Task OnParametersSetAsync()
     {
-        isLoading = true;
-        if (nft != null && nft.id != nftId) //did we change to another NFT?
-        {
-            nft = null;
-            transactions = new List<Transaction>();
-            pageNumber = "1";
-            StateHasChanged();
-        }
-        if (nftId == null) return;
-        if (nft == null)
-        {
-            nftMetadata = null;
-            string nftCacheKey = $"nft-{nftId}";
-            nft = await AppCache.GetOrAddAsyncNonNull(nftCacheKey, async () => await LoopringGraphQLService.GetNFT(nftId));
-            if (nft == null) return;
-            StateHasChanged();
-        }
+        //cancel any previous OnParametersSetAsync which might still be running
+        cts?.Cancel();
 
-        if (String.IsNullOrEmpty(pageNumber))
+        using (CancellationTokenSource localCTS = new CancellationTokenSource())
         {
-            pageNumber = "1";
-        }
-
-        string nftTransactionCacheKey = $"nft{nftId}-transactions-page{pageNumber}";
-        transactions = await AppCache.GetOrAddAsyncNonNull(nftTransactionCacheKey,
-            async () => await LoopringGraphQLService.GetNFTTransactions((gotoPage - 1) * pageSize, pageSize, nftId),
-            DateTimeOffset.UtcNow.AddMinutes(10));
-        isLoading = false;
-        StateHasChanged();
-
-        //load the NFT metadata last - it might actually take the longest and other services are queried etc.
-        if (nftMetadata == null)
-        {
-            string nftMetadataLinkCacheKey = $"nftMetadataLink-{nft?.nftID}";
-            string? nftMetadataLink = await AppCache.GetOrAddAsyncNonNull(nftMetadataLinkCacheKey, async () => await EthereumService.GetMetadataLink(nft?.nftID, nft?.token, nft?.nftType));
-            if (String.IsNullOrEmpty(nftMetadataLink)) return;
-
-            string nftMetadataCacheKey = $"nftMetadata-{nftMetadataLink}";
-            nftMetadata = await AppCache.GetOrAddAsyncNonNull(nftMetadataCacheKey, async () => await NftMetadataService.GetMetadata(nftMetadataLink));
-            if (!String.IsNullOrEmpty(nftMetadata?.animation_url))
+            //give future calls a chance to cancel us; it is now safe to replace
+            //any previous value of cts, since we already cancelled it above
+            cts = localCTS;
+            try
             {
-                string nftMetadataContentTypeCacheKey = $"nftMetadata-contentType-{nftMetadataLink}";
-                nftMetadata!.contentType = await AppCache.GetOrAddAsyncNonNull(nftMetadataContentTypeCacheKey,
-                    async () => await NftMetadataService.GetContentTypeFromURL(nftMetadata.animationURL!));
-            }
-            StateHasChanged();
-        }
+                isLoading = true;
+                if (nft != null && nft.id != nftId) //did we change to another NFT?
+                {
+                    nft = null;
+                    transactions = new List<Transaction>();
+                    pageNumber = "1";
+                    StateHasChanged();
+                }
+                if (nftId == null) return;
+                if (nft == null)
+                {
+                    nftMetadata = null;
+                    string nftCacheKey = $"nft-{nftId}";
+                    nft = await AppCache.GetOrAddAsyncNonNull(nftCacheKey,
+                        async () => await LoopringGraphQLService.GetNFT(nftId, localCTS.Token),
+                        DateTimeOffset.UtcNow.AddHours(1));
+                    if (nft == null) return;
+                    StateHasChanged();
+                }
 
+                if (String.IsNullOrEmpty(pageNumber))
+                {
+                    pageNumber = "1";
+                }
+
+                string nftTransactionCacheKey = $"nft{nftId}-transactions-page{pageNumber}";
+                transactions = await AppCache.GetOrAddAsyncNonNull(nftTransactionCacheKey,
+                    async () => await LoopringGraphQLService.GetNFTTransactions((gotoPage - 1) * pageSize, pageSize, nftId, localCTS.Token),
+                    DateTimeOffset.UtcNow.AddMinutes(10));
+                isLoading = false;
+                StateHasChanged();
+
+                //load the NFT metadata last - it might actually take the longest and other services are queried etc.
+                if (nftMetadata == null)
+                {
+                    string nftMetadataLinkCacheKey = $"nftMetadataLink-{nft?.nftID}";
+                    string? nftMetadataLink = await AppCache.GetOrAddAsyncNonNull(nftMetadataLinkCacheKey,
+                        async () => await EthereumService.GetMetadataLink(nft?.nftID, nft?.token, nft?.nftType));
+                    if (String.IsNullOrEmpty(nftMetadataLink)) return;
+
+                    string nftMetadataCacheKey = $"nftMetadata-{nftMetadataLink}";
+                    nftMetadata = await AppCache.GetOrAddAsyncNonNull(nftMetadataCacheKey,
+                        async () => await NftMetadataService.GetMetadata(nftMetadataLink, localCTS.Token));
+                    if (!String.IsNullOrEmpty(nftMetadata?.animation_url))
+                    {
+                        string nftMetadataContentTypeCacheKey = $"nftMetadata-contentType-{nftMetadataLink}";
+                        nftMetadata!.contentType = await AppCache.GetOrAddAsyncNonNull(nftMetadataContentTypeCacheKey,
+                            async () => await NftMetadataService.GetContentTypeFromURL(nftMetadata.animationURL!, localCTS.Token));
+                    }
+                    StateHasChanged();
+                }
+
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (Exception e)
+            {
+                Trace.WriteLine(e.StackTrace + "\n" + e.Message);
+            }
+            //now for cleanup, we must clear cts, but only if it is still our localCTS, which we're about to dispose
+            //otherwise a new call has already replaced cts with it's own localCTS
+            Interlocked.CompareExchange<CancellationTokenSource?>(ref cts, null, localCTS);
+        }
     }
 
 }

--- a/Lexplorer/Pages/NFTDetail.razor
+++ b/Lexplorer/Pages/NFTDetail.razor
@@ -47,15 +47,25 @@
             <td>Animation URL</td>
             <td>@nftMetadata?.animation_url</td>
         </tr>
-        @if(nftMetadata?.attributes?.Count > 0)
+        @if (nftMetadata?.attributes?.Count > 0)
         {
             <tr>
-                <td>Traits</td>
-                <td>
-                    @foreach(var trait in nftMetadata?.attributes!)
-                    {
-                        <p>@trait.trait_type:@trait.value</p>
-                    }
+                <td colspan="2">
+                    <MudExpansionPanels>
+                        <MudExpansionPanel Text="Traits">
+                            <MudSimpleTable Dense="true" Striped="true" Bordered="true">
+                                <tbody>
+                                    @foreach (var trait in nftMetadata?.attributes!)
+                                    {
+                                        <tr>
+                                            <td>@trait.trait_type</td>
+                                            <td>@trait.value</td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </MudSimpleTable>
+                        </MudExpansionPanel>
+                    </MudExpansionPanels>
                 </td>
             </tr>
         }

--- a/Lexplorer/Pages/NFTOverview.razor
+++ b/Lexplorer/Pages/NFTOverview.razor
@@ -68,7 +68,7 @@
         }
 
         string nftsCacheKey = $"nfts-page{pageNumber}";
-        nfts = await AppCache.GetOrAddAsync(nftsCacheKey,
+        nfts = await AppCache.GetOrAddAsyncNonNull(nftsCacheKey,
             async () => await LoopringGraphQLService.GetNFTs((gotoPage - 1) * pageSize, pageSize),
             DateTimeOffset.UtcNow.AddMinutes(10));
         isLoading = false;

--- a/Lexplorer/Pages/PairsOverview.razor
+++ b/Lexplorer/Pages/PairsOverview.razor
@@ -79,12 +79,12 @@ else
         }
         isLoading = true;
         string pairsCacheKey = $"pairsOverview-pairs-page{pageNumber}";
-        pairsData = await AppCache.GetOrAddAsync(pairsCacheKey, async () => await LoopringGraphQLService.GetPairs(Int32.Parse(pageNumber) * 10), DateTimeOffset.UtcNow.AddHours(1));
+        pairsData = await AppCache.GetOrAddAsyncNonNull(pairsCacheKey, async () => await LoopringGraphQLService.GetPairs(Int32.Parse(pageNumber) * 10), DateTimeOffset.UtcNow.AddHours(1));
         int pairCount = 0;
         foreach (var pair in pairsData!.data!.pairs!)
         {
             string uniswapTokenCacheKey = $"pairsOverview-token-{pair!.token1!.address!}-pageNumber{pageNumber}";
-            var uniswapToken = await AppCache.GetOrAddAsync(uniswapTokenCacheKey, async () => await UniswapGraphQLService.GetTokenPrice(pair!.token1!.address!), DateTimeOffset.UtcNow.AddHours(1));
+            var uniswapToken = await AppCache.GetOrAddAsyncNonNull(uniswapTokenCacheKey, async () => await UniswapGraphQLService.GetTokenPrice(pair!.token1!.address!), DateTimeOffset.UtcNow.AddHours(1));
             if(uniswapToken != null && pairCount == 0)
             {
                 uniswapTokens = new List<UniswapToken>();

--- a/Lexplorer/Pages/TransactionDetail.razor
+++ b/Lexplorer/Pages/TransactionDetail.razor
@@ -381,7 +381,7 @@
         string transactionCacheKey = $"transactionDetail-{transactionId}";
         if (transaction?.id != transactionId)
         {
-            transaction = await AppCache.GetOrAddAsync(transactionCacheKey, async () => await LoopringGraphQLService.GetTransaction(transactionId));
+            transaction = await AppCache.GetOrAddAsyncNonNull(transactionCacheKey, async () => await LoopringGraphQLService.GetTransaction(transactionId));
             StateHasChanged();
         }
     }

--- a/Lexplorer/Pages/TransactionsOverview.razor
+++ b/Lexplorer/Pages/TransactionsOverview.razor
@@ -100,7 +100,7 @@
         }
 
         string transactionCacheKey = $"transactions-page{pageNumber}-type{type}";
-        var transactionsData = await AppCache.GetOrAddAsync(transactionCacheKey,
+        var transactionsData = await AppCache.GetOrAddAsyncNonNull(transactionCacheKey,
             async () => await LoopringGraphQLService.GetTransactions((gotoPage - 1) * pageSize, pageSize, typeName: type),
             DateTimeOffset.UtcNow.AddMinutes(10));
         transactions = transactionsData?.data?.transactions;

--- a/Shared/Services/EthereumService.cs
+++ b/Shared/Services/EthereumService.cs
@@ -34,7 +34,7 @@ namespace Lexplorer.Services
                 var function = contract.GetFunction(functionName);
                 object[] parameters = new object[1] { tokenId! };
                 var uri = await function.CallAsync<string>(parameters);
-                return uri?.StartsWith("ipfs://") ?? false ? uri?.Remove(0, 7) : uri; //remove the ipfs portion
+                return uri;
             }
             catch (Exception e)
             {

--- a/Shared/Services/EthereumService.cs
+++ b/Shared/Services/EthereumService.cs
@@ -51,8 +51,7 @@ namespace Lexplorer.Services
            
             try
             {
-                string address = await ensService.ResolveAddressAsync(ens);
-                return address; //remove the ipfs portion
+                return await ensService.ResolveAddressAsync(ens);
             }
             catch (Exception e)
             {

--- a/Shared/Services/LoopringGraphQLService.cs
+++ b/Shared/Services/LoopringGraphQLService.cs
@@ -977,7 +977,7 @@ namespace Lexplorer.Services
             }
         }
 
-        public async Task<NonFungibleToken?> GetNFT(string NFTId)
+        public async Task<NonFungibleToken?> GetNFT(string NFTId, CancellationToken cancellationToken = default)
         {
             var NFTQuery = @"
               query nonFungibleTokenQuery($id: ID!) {
@@ -1009,7 +1009,7 @@ namespace Lexplorer.Services
 
             try
             {
-                var response = await _client.PostAsync(request);
+                var response = await _client.PostAsync(request, cancellationToken);
                 JObject jresponse = JObject.Parse(response.Content!);
                 JToken result = jresponse["data"]!["nonFungibleToken"]!;
                 return result.ToObject<NonFungibleToken>();
@@ -1021,7 +1021,7 @@ namespace Lexplorer.Services
             }
         }
 
-        public async Task<string?> GetNFTTransactionsResponse(int skip, int first, string nftId)
+        public async Task<string?> GetNFTTransactionsResponse(int skip, int first, string nftId, CancellationToken cancellationToken = default)
         {
             var nftQuery = @"
             query nftTransactions(
@@ -1083,7 +1083,7 @@ namespace Lexplorer.Services
             request.AddStringBody(jObject.ToString(), ContentType.Json);
             try
             {
-                var response = await _client.PostAsync(request);
+                var response = await _client.PostAsync(request, cancellationToken);
                 return response.Content;
             }
             catch (Exception ex)
@@ -1093,11 +1093,11 @@ namespace Lexplorer.Services
             }
         }
 
-        public async Task<IList<Transaction>?> GetNFTTransactions(int skip, int first, string nftId)
+        public async Task<IList<Transaction>?> GetNFTTransactions(int skip, int first, string nftId, CancellationToken cancellationToken = default)
         {
             try
             {
-                string? response = await GetNFTTransactionsResponse(skip, first, nftId);
+                string? response = await GetNFTTransactionsResponse(skip, first, nftId, cancellationToken);
                 JObject jresponse = JObject.Parse(response!);
                 JToken? token = jresponse["data"]!["nonFungibleToken"]!["transactions"];
                 return token!.ToObject<IList<Transaction>>();

--- a/Shared/Services/NftMetadataService.cs
+++ b/Shared/Services/NftMetadataService.cs
@@ -60,7 +60,7 @@ namespace Lexplorer.Services
             }
         }
 
-        public async Task<string> GetContentTypeFromURL(string link, CancellationToken cancellationToken = default)
+        public async Task<string?> GetContentTypeFromURL(string link, CancellationToken cancellationToken = default)
         {
             link = makeAbsolutelink(link);
             var request = new RestRequest(link, Method.Head);
@@ -68,22 +68,12 @@ namespace Lexplorer.Services
             {
                 request.Timeout = 20000; //we can't afford to wait forever here, 20s must be enough
                 var response = await _client.HeadAsync(request, cancellationToken); //Send head request so we only get header not the content
-                Dictionary<string, string> contentHeaders = new Dictionary<string, string>();
-                foreach(var item in response.ContentHeaders!)
-                {
-                    contentHeaders.Add(item.Name!, item!.Value!.ToString()!);
-                }
-                string contentType = "";
-                if(!contentHeaders.TryGetValue("Content-Type", out contentType!))
-                {
-                    //the key doesn't exist
-                }
-                return contentType!;
+                return response?.ContentType;
             }
             catch (Exception e)
             {
                 Trace.WriteLine(e.StackTrace + "\n" + e.Message);
-                return null!;
+                return null;
             }
         }
 

--- a/Shared/Services/NftMetadataService.cs
+++ b/Shared/Services/NftMetadataService.cs
@@ -12,13 +12,18 @@ namespace Lexplorer.Services
 {
     public class NftMetadataService : IDisposable
     {
-        const string BaseUrl = "https://fudgey.mypinata.cloud/ipfs/";
+        const string _ipfsBaseUrl = "https://fudgey.mypinata.cloud/ipfs/";
 
         readonly RestClient _client;
 
+        private string makeAbsolutelink(string link)
+        {
+            return link.StartsWith("ipfs://") ? _ipfsBaseUrl + link.Remove(0, 7) : link; //remove the ipfs portion and add base
+        }
+
         public NftMetadataService()
         {
-            _client = new RestClient(BaseUrl);
+            _client = new RestClient();
         }
 
         public void Dispose()
@@ -29,6 +34,7 @@ namespace Lexplorer.Services
 
         public async Task<NftMetadata?> GetMetadata(string link, CancellationToken cancellationToken = default)
         {
+            link = makeAbsolutelink(link);
             //there is a fallback for if the metadata fails on the first try because
             //loopring deployed two different contracts for the nfts so some
             //metadata.json needs to be referenced directly while others are in a folder in ipfs
@@ -56,6 +62,7 @@ namespace Lexplorer.Services
 
         public async Task<string> GetContentTypeFromURL(string link, CancellationToken cancellationToken = default)
         {
+            link = makeAbsolutelink(link);
             var request = new RestRequest(link, Method.Head);
             try
             {

--- a/xUnitTests/NFTMetaDataTests/TestNFTMetaData.cs
+++ b/xUnitTests/NFTMetaDataTests/TestNFTMetaData.cs
@@ -84,7 +84,7 @@ namespace xUnitTests.NFTMetaDataTests
 			Assert.NotNull(meta);
 
 			var contentType = await fixture.NMS.GetContentTypeFromURL(meta!.animation_url!);
-			Assert.True(new List<string> { "application/octet-stream", "model/gltf-binary" }.Contains(contentType), $"unexpected contentType \"{contentType}\"");
+			Assert.True(new List<string> { "application/octet-stream", "model/gltf-binary" }.Contains(contentType!), $"unexpected contentType \"{contentType}\"");
 		}
 
 		[Theory]

--- a/xUnitTests/NFTMetaDataTests/TestNFTMetaData.cs
+++ b/xUnitTests/NFTMetaDataTests/TestNFTMetaData.cs
@@ -41,7 +41,7 @@ namespace xUnitTests.NFTMetaDataTests
 			var meta = await fixture.NMS.GetMetadata(link!);
 			Assert.NotNull(meta);
 
-			var contentType = await fixture.NMS.GetContentTypeFromURL(meta!.animation_url!.StartsWith("ipfs://") ? meta!.animation_url.Remove(0, 7) : meta!.animation_url);
+			var contentType = await fixture.NMS.GetContentTypeFromURL(meta!.animation_url!);
 			Assert.Equal("video/mp4", contentType);
 		}
 
@@ -55,7 +55,7 @@ namespace xUnitTests.NFTMetaDataTests
 			var meta = await fixture.NMS.GetMetadata(link!);
 			Assert.NotNull(meta);
 
-			var contentType = await fixture.NMS.GetContentTypeFromURL(meta!.animation_url!.StartsWith("ipfs://") ? meta!.animation_url.Remove(0, 7) : meta!.animation_url);
+			var contentType = await fixture.NMS.GetContentTypeFromURL(meta!.animation_url!);
 			Assert.Equal("image/jpeg", contentType);
 		}
 
@@ -69,7 +69,7 @@ namespace xUnitTests.NFTMetaDataTests
 			var meta = await fixture.NMS.GetMetadata(link!);
 			Assert.NotNull(meta);
 
-			var contentType = await fixture.NMS.GetContentTypeFromURL(meta!.animation_url!.StartsWith("ipfs://") ? meta!.animation_url.Remove(0, 7) : meta!.animation_url);
+			var contentType = await fixture.NMS.GetContentTypeFromURL(meta!.animation_url!);
 			Assert.Equal("audio/mpeg", contentType);
 		}
 
@@ -83,7 +83,7 @@ namespace xUnitTests.NFTMetaDataTests
 			var meta = await fixture.NMS.GetMetadata(link!);
 			Assert.NotNull(meta);
 
-			var contentType = await fixture.NMS.GetContentTypeFromURL(meta!.animation_url!.StartsWith("ipfs://") ? meta!.animation_url.Remove(0, 7) : meta!.animation_url);
+			var contentType = await fixture.NMS.GetContentTypeFromURL(meta!.animation_url!);
 			Assert.True(new List<string> { "application/octet-stream", "model/gltf-binary" }.Contains(contentType), $"unexpected contentType \"{contentType}\"");
 		}
 
@@ -97,7 +97,7 @@ namespace xUnitTests.NFTMetaDataTests
 			var meta = await fixture.NMS.GetMetadata(link!);
 			Assert.NotNull(meta);
 
-			var contentType = await fixture.NMS.GetContentTypeFromURL(meta!.animation_url!.StartsWith("ipfs://") ? meta!.animation_url.Remove(0, 7) : meta!.animation_url);
+			var contentType = await fixture.NMS.GetContentTypeFromURL(meta!.animation_url!);
 			Assert.Equal("text/html", contentType);
 		}
 	}

--- a/xUnitTests/NFTMetaDataTests/TestNFTMetaData.cs
+++ b/xUnitTests/NFTMetaDataTests/TestNFTMetaData.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Xunit;
 using Lexplorer.Services;
+using System.Collections.Generic;
 
 namespace xUnitTests.NFTMetaDataTests
 {
@@ -83,7 +84,7 @@ namespace xUnitTests.NFTMetaDataTests
 			Assert.NotNull(meta);
 
 			var contentType = await fixture.NMS.GetContentTypeFromURL(meta!.animation_url!.StartsWith("ipfs://") ? meta!.animation_url.Remove(0, 7) : meta!.animation_url);
-			Assert.Equal("application/octet-stream", contentType);
+			Assert.True(new List<string> { "application/octet-stream", "model/gltf-binary" }.Contains(contentType), $"unexpected contentType \"{contentType}\"");
 		}
 
 		[Theory]


### PR DESCRIPTION
This became quite a loose collection of smaller and bigger improvements.

After PR #99 I cleaned up MetaData URL handling. The redirection of ipfs:// links via piñata is now done at the latest possible moment, when downloading the meta data. The RestClient now longer has a baseURL (even though it did indeed work requesting other URLs).

I didn't include the code I tried for #85 simply because I'm not sure this is actually improving things.

I See that you reverted the test for the NFT model content type - I've actually extended it here, so it accepts both. Strangely enough, even if my GitHub action runs on Linux, it got the correct content type. So anyways, just as a warning: this might create a conflict once you merge this to master.