### PR TITLE
Fix Invalid query error when using non-hosted graph

### DIFF
--- a/Lexplorer/Pages/BlockDetails.razor
+++ b/Lexplorer/Pages/BlockDetails.razor
@@ -153,7 +153,7 @@
                 isTransactionLoading = true;
                 string transactionDatacacheKey = $"blockDetailTransactions-{blockId}-page{gotoPage}";
                 var transactionData = await AppCache.GetOrAddAsyncNonNull(transactionDatacacheKey,
-                    async () => await LoopringGraphQLService.GetTransactions((gotoPage - 1) * pageSize, pageSize, blockNumber, cancellationToken: localCTS.Token),
+                    async () => await LoopringGraphQLService.GetTransactions((gotoPage - 1) * pageSize, pageSize, blockId: blockNumber, cancellationToken: localCTS.Token),
                     DateTimeOffset.UtcNow.AddMinutes(5));
                 transactions = transactionData?.data?.transactions ?? new List<Transaction>();
                 isTransactionLoading = false;

--- a/Shared/Services/LoopringGraphQLService.cs
+++ b/Shared/Services/LoopringGraphQLService.cs
@@ -298,7 +298,7 @@ namespace Lexplorer.Services
             }
         }
 
-        public async Task<Transactions?> GetTransactions(int skip, int first, string? typeName = null, CancellationToken cancellationToken = default)
+        public async Task<Transactions?> GetTransactions(int skip, int first, string? blockId = null, string? typeName = null, CancellationToken cancellationToken = default)
         {
             var transactionsQuery = @"
               query transactions(
@@ -306,6 +306,7 @@ namespace Lexplorer.Services
                 $first: Int
                 $orderBy: Transaction_orderBy
                 $orderDirection: OrderDirection
+                $block: Block_height
                 $whereFilter: Transaction_filter
               ) {
                 proxy(id: 0) {
@@ -332,6 +333,7 @@ namespace Lexplorer.Services
                   first: $first
                   orderBy: $orderBy
                   orderDirection: $orderDirection
+                  block: $block
                   where: $whereFilter
                 ) {
                   id
@@ -401,7 +403,26 @@ namespace Lexplorer.Services
 
             var request = new RestRequest();
             request.AddHeader("Content-Type", "application/json");
-            if (typeName != null)
+            if (blockId != null)
+            {
+                request.AddJsonBody(new
+                {
+                    query = transactionsQuery,
+                    variables = new
+                    {
+                        skip = skip,
+                        first = first,
+                        orderBy = "internalID",
+                        orderDirection = "desc"
+                        ,
+                        whereFilter = new
+                        {
+                            block = blockId
+                        }
+                    }
+                });
+            }
+            else if (typeName != null)
             {
                 request.AddJsonBody(new
                 {

--- a/xUnitTests/LoopringGraphTests/TestTransaction.cs
+++ b/xUnitTests/LoopringGraphTests/TestTransaction.cs
@@ -25,6 +25,23 @@ namespace xUnitTests.LoopringGraphTests
             Assert.NotNull(transaction);
             Assert.Equal(testID, transaction!.id);
         }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("Swap")]
+        public async void TestGetTransations(string? typeName)
+        {
+            var transactions = await service.GetTransactions(0, 5, typeName);
+            Assert.NotNull(transactions);
+            Assert.NotEmpty(transactions?.data?.transactions);
+            if (!String.IsNullOrEmpty(typeName))
+            {
+                foreach (var transaction in transactions?.data?.transactions!)
+                {
+                    Assert.Equal(typeName, transaction.typeName);
+                }
+            }
+        }
     }
 }
 

--- a/xUnitTests/LoopringGraphTests/TestTransaction.cs
+++ b/xUnitTests/LoopringGraphTests/TestTransaction.cs
@@ -31,7 +31,7 @@ namespace xUnitTests.LoopringGraphTests
         [InlineData("Swap")]
         public async void TestGetTransations(string? typeName)
         {
-            var transactions = await service.GetTransactions(0, 5, typeName);
+            var transactions = await service.GetTransactions(0, 5, typeName: typeName);
             Assert.NotNull(transactions);
             Assert.NotEmpty(transactions?.data?.transactions);
             if (!String.IsNullOrEmpty(typeName))
@@ -41,6 +41,15 @@ namespace xUnitTests.LoopringGraphTests
                     Assert.Equal(typeName, transaction.typeName);
                 }
             }
+        }
+
+        [Theory]
+        [InlineData("19527")]
+        public async void TestGetBlockTransations(string? blockId)
+        {
+            var transactions = await service.GetTransactions(0, 5, blockId: blockId);
+            Assert.NotNull(transactions);
+            Assert.NotEmpty(transactions?.data?.transactions);
         }
     }
 }


### PR DESCRIPTION
* as described in #50 - the non-hosted graphs don't like unused query parameters
* removed block from query completely, was never used
* if no typename is provided, delete the lines in the query
* added new tests for GetTransactions