### PR TITLE
Feature: Nft balance chip

### DIFF
--- a/Lexplorer/Pages/Account.razor
+++ b/Lexplorer/Pages/Account.razor
@@ -84,9 +84,9 @@
                             <MudCard Style="height:100%;position:relative">
                                 <MudCardMedia Image="@metaData?.imageURL" Style="object-fit:contain" />
                                 <MudCardContent>
-                                    <MudText Typo="Typo.h5">@metaData?.name</MudText>
+                                    <MudText Typo="Typo.h6">@metaData?.name</MudText>
+                                    <MudChip Label="true" Color="Color.Primary" Class="ml-0">x @slot.balance.ToString("#,##0")</MudChip>
                                     <MudText Typo="Typo.body2">@metaData?.description</MudText>
-                                    <MudText Typo="Typo.body2">Balance: @slot.balance.ToString("#,##0")</MudText>
                                 </MudCardContent>
                                 <MudCardActions>
                                     <MudButton Style="position:absolute;bottom:0;" Variant="Variant.Text" Color="Color.Primary" Link=@LinkHelper.GetObjectLinkAddress(slot.nft)?.Item1>Go to NFT</MudButton>


### PR DESCRIPTION
## Feature
* Added MudChip to show balance of NFTs
* Set name of NFT to H6 instead of H5 for readability

(I hope this is done the correct way now)

## View
| Desktop | Mobile |
|----------|---------|
|![image](https://user-images.githubusercontent.com/58626043/165920968-31192cc4-fb2d-427d-8bbb-c2434b111277.png)|![image](https://user-images.githubusercontent.com/58626043/165921134-67b982d0-843b-46e1-b19d-4ec398d9ff30.png)|