### PR TITLE
Automatically start in DarkMode if user has this enabled locally

### DIFF
--- a/Lexplorer/Pages/_Host.cshtml
+++ b/Lexplorer/Pages/_Host.cshtml
@@ -23,6 +23,10 @@ function triggerFileDownload(fileName, url) {
   anchorElement.href = url;
   anchorElement.download = fileName ?? '';
   anchorElement.click();
-  anchorElement.remove();
+    anchorElement.remove();
+}
+
+window.prefersDarkMode = function(){
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
 }
 </script>

--- a/Lexplorer/Shared/MainLayout.razor
+++ b/Lexplorer/Shared/MainLayout.razor
@@ -3,6 +3,7 @@
 @inject Lexplorer.Services.LoopringGraphQLService LoopringGraphQLService;
 @inject NavigationManager NavigationManager;
 @inject Lexplorer.Services.EthereumService EthereumService;
+@inject IJSRuntime JS;
 
 <MudThemeProvider @bind-IsDarkMode="@_isDarkMode" Theme="_theme" />
 <MudDialogProvider />
@@ -85,6 +86,11 @@
     protected override void OnInitialized()
     {
         NavigationManager.LocationChanged += OnLocationChanged;
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        _isDarkMode = await JS.InvokeAsync<bool>("prefersDarkMode");
     }
 
     private async void DoSearch()


### PR DESCRIPTION
Back when I made #102 I left DarkMode off by default, because I was hoping to have it a) correctly enabled depending on users settings and b) have it persistent for users across sessions.

Both are covered in https://jonhilton.net/blazor-tailwind-dark-mode-local-storage/ but I'm only going for the initial setting for now.

Will keep it as a draft for now, but could already be merged if desired.