### PR TITLE
Fix GetPools where pool id 114 has feeBipsAMM = null

### DIFF
--- a/Shared/Models/LoopringV3.cs
+++ b/Shared/Models/LoopringV3.cs
@@ -108,7 +108,7 @@ namespace Lexplorer.Models
     }
     public class Pool : Account
     {
-        public int feeBipsAMM { get; set; }
+        public Int32? feeBipsAMM { get; set; }
     }
     public class Pair
     {


### PR DESCRIPTION
With my last merge the action had a failed test in GetPools - because it returned null. Upon debugging I saw the JSON conversion failed because pool id 114 has feeBipsAMM = null. This bug can also be seen in production if you go to the Accounts page and filter by Pool - the page will remain empty.

Fix is to make the field nullable.