### PR TITLE
Feature: search dialog on small devices

### DIFF
--- a/Lexplorer.sln
+++ b/Lexplorer.sln
@@ -7,7 +7,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lexplorer", "Lexplorer\Lexp
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Shared", "Shared\Shared.shproj", "{E3CCB3F9-47E9-4F8E-85D6-9C964F24367C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "xUnitTests", "xUnitTests\xUnitTests.csproj", "{246057E4-2CD6-46C3-9A50-37D8E365DD1E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "xUnitTests", "xUnitTests\xUnitTests.csproj", "{246057E4-2CD6-46C3-9A50-37D8E365DD1E}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution

--- a/Lexplorer/Dialogs/SearchDialog.razor
+++ b/Lexplorer/Dialogs/SearchDialog.razor
@@ -1,0 +1,19 @@
+﻿<MudDialog>
+    <DialogContent>
+        <div class="d-flex flex-column py-1">
+            <MudTextField @bind-Value="SearchTerm" Label="Searchterm..." Variant="Variant.Text"/>
+        </div>
+    </DialogContent>
+    <DialogActions>
+        <MudButton Color="Color.Primary" OnClick="DoDialogSearch">Search</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] MudDialogInstance MudDialog { get; set; }
+
+    private string SearchTerm { get; set; }
+
+    void DoDialogSearch() => MudDialog.Close(DialogResult.Ok(SearchTerm));
+
+}

--- a/Lexplorer/Shared/MainLayout.razor
+++ b/Lexplorer/Shared/MainLayout.razor
@@ -131,9 +131,7 @@
 
         if (!result.Cancelled)
         {
-            searchTerm = result.Data == null 
-                ? ""
-                : result.Data.ToString();
+            searchTerm = result?.Data?.ToString();
 
             DoSearch();
         }

--- a/Lexplorer/Shared/MainLayout.razor
+++ b/Lexplorer/Shared/MainLayout.razor
@@ -125,7 +125,7 @@
 
     async Task DialogSearch()
     {
-        DialogOptions maxWidth = new DialogOptions() { MaxWidth = MaxWidth.Medium, FullWidth = true };
+        DialogOptions maxWidth = new DialogOptions() { MaxWidth = MaxWidth.Medium, FullWidth = true, Position = DialogPosition.TopCenter };
         var dialog = DialogService.Show<SearchDialog>("Search", maxWidth);
         var result = await dialog.Result;
 

--- a/Lexplorer/Shared/MainLayout.razor
+++ b/Lexplorer/Shared/MainLayout.razor
@@ -3,6 +3,7 @@
 @inject NavigationManager NavigationManager;
 @inject EthereumService EthereumService;
 @inject IJSRuntime JS;
+@inject IDialogService DialogService
 
 <MudThemeProvider @bind-IsDarkMode="@_isDarkMode" Theme="_theme" />
 <MudDialogProvider />
@@ -13,8 +14,9 @@
         <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@((e) => DrawerToggle())" />
         <MudText Typo="Typo.h6" Class="d-none d-sm-flex">The Lexplorer</MudText>
         <MudSpacer />
-        <MudTextField Style="@($"background:var(--mud-palette-background);")" @bind-Value="searchTerm" Label="Search account, block or transaction" Variant="Variant.Outlined" Adornment="Adornment.End" AdornmentIcon="@Icons.Filled.Search" AdornmentColor="Color.Info" OnAdornmentClick="DoSearch" Margin="Margin.Dense" />
+        <MudTextField Class="d-none d-sm-flex" Style="@($"background:var(--mud-palette-background);")" @bind-Value="searchTerm" Label="Search account, block or transaction" Variant="Variant.Outlined" Adornment="Adornment.End" AdornmentIcon="@Icons.Filled.Search" AdornmentColor="Color.Info" OnAdornmentClick="DoSearch" Margin="Margin.Dense" />
         <MudSpacer />
+        <MudIconButton Class="d-flex d-sm-none" Icon="@Icons.Filled.Search" OnClick="DialogSearch"/>
         <MudToggleIconButton @bind-Toggled="@_isDarkMode"
                              Icon="@Icons.Filled.DarkMode" Color="Color.Inherit" Title="DarkMode"
                              ToggledIcon="@Icons.Filled.LightMode" ToggledTitle="LightMode" />
@@ -119,5 +121,21 @@
         }
         searching = false;
         StateHasChanged();
+    }
+
+    async Task DialogSearch()
+    {
+        DialogOptions maxWidth = new DialogOptions() { MaxWidth = MaxWidth.Medium, FullWidth = true };
+        var dialog = DialogService.Show<SearchDialog>("Search", maxWidth);
+        var result = await dialog.Result;
+
+        if (!result.Cancelled)
+        {
+            searchTerm = result.Data == null 
+                ? ""
+                : result.Data.ToString();
+
+            DoSearch();
+        }
     }
 }

--- a/Lexplorer/_Imports.razor
+++ b/Lexplorer/_Imports.razor
@@ -14,3 +14,4 @@
 @using Lexplorer.Services
 @using Lexplorer.Components
 @using LazyCache;
+@using Lexplorer.Dialogs


### PR DESCRIPTION
Closes #127 

## Feature: 
* Added SearchDialog with textfield and search button
* Updated mainlayout to show searchfield on larger devices and hide on smaller.
* Updated mainlayout to show iconbutton on small devices and hide on large which triggers dialog
* Searchterm from dialog gets sent as dialog result and sets searchTerm if not null. 

## View:
| Large device | Small device |
|---------------|---------------|
| ![image](https://user-images.githubusercontent.com/58626043/166142267-2a8910c5-7af1-4ba8-9b59-adaffb27e682.png) | ![image](https://user-images.githubusercontent.com/58626043/166142341-15d47724-c883-49f8-be0d-06eb3376b733.png) |  

### Dialog:
![image](https://user-images.githubusercontent.com/58626043/166142484-33f82632-5ea2-46af-8cb7-f629fdee747f.png)


