### PR TITLE
Fix: search dialog fixes

### DIFF
--- a/Lexplorer/Dialogs/SearchDialog.razor
+++ b/Lexplorer/Dialogs/SearchDialog.razor
@@ -1,7 +1,7 @@
 ﻿<MudDialog>
     <DialogContent>
         <div class="d-flex flex-column py-1">
-            <MudTextField @bind-Value="searchTerm" Label="Searchterm..." Variant="Variant.Outlined" Adornment="Adornment.End" AdornmentIcon="@Icons.Filled.Search" AdornmentColor="Color.Info" OnAdornmentClick="DoDialogSearch" Margin="Margin.Dense" />
+            <MudTextField AutoFocus="true" @bind-Value="searchTerm" Label="Searchterm..." Variant="Variant.Outlined" Adornment="Adornment.End" AdornmentIcon="@Icons.Filled.Search" AdornmentColor="Color.Info" OnAdornmentClick="DoDialogSearch" Margin="Margin.Dense" />
         </div>
     </DialogContent>
     <DialogActions>

--- a/Lexplorer/Dialogs/SearchDialog.razor
+++ b/Lexplorer/Dialogs/SearchDialog.razor
@@ -1,7 +1,7 @@
 ﻿<MudDialog>
     <DialogContent>
         <div class="d-flex flex-column py-1">
-            <MudTextField @bind-Value="SearchTerm" Label="Searchterm..." Variant="Variant.Text"/>
+            <MudTextField @bind-Value="searchTerm" Label="Searchterm..." Variant="Variant.Outlined" Adornment="Adornment.End" AdornmentIcon="@Icons.Filled.Search" AdornmentColor="Color.Info" OnAdornmentClick="DoDialogSearch" Margin="Margin.Dense" />
         </div>
     </DialogContent>
     <DialogActions>
@@ -12,8 +12,17 @@
 @code {
     [CascadingParameter] MudDialogInstance MudDialog { get; set; }
 
-    private string SearchTerm { get; set; }
+    private string? _searchTerm;
+    private string? searchTerm
+    {
+        get { return _searchTerm; }
+        set
+        {
+            _searchTerm = value;
+            DoDialogSearch();
+        }
+    }
 
-    void DoDialogSearch() => MudDialog.Close(DialogResult.Ok(SearchTerm));
+    void DoDialogSearch() => MudDialog.Close(DialogResult.Ok(searchTerm));
 
 }

--- a/Lexplorer/Shared/MainLayout.razor
+++ b/Lexplorer/Shared/MainLayout.razor
@@ -16,7 +16,7 @@
         <MudSpacer />
         <MudTextField Class="d-none d-sm-flex" Style="@($"background:var(--mud-palette-background);")" @bind-Value="searchTerm" Label="Search account, block or transaction" Variant="Variant.Outlined" Adornment="Adornment.End" AdornmentIcon="@Icons.Filled.Search" AdornmentColor="Color.Info" OnAdornmentClick="DoSearch" Margin="Margin.Dense" />
         <MudSpacer />
-        <MudIconButton Class="d-flex d-sm-none" Icon="@Icons.Filled.Search" OnClick="DialogSearch"/>
+        <MudIconButton Class="d-flex d-sm-none" Icon="@Icons.Filled.Search" OnClick="DialogSearch" Color="Color.Inherit"/>
         <MudToggleIconButton @bind-Toggled="@_isDarkMode"
                              Icon="@Icons.Filled.DarkMode" Color="Color.Inherit" Title="DarkMode"
                              ToggledIcon="@Icons.Filled.LightMode" ToggledTitle="LightMode" />

--- a/Lexplorer/Shared/MainLayout.razor
+++ b/Lexplorer/Shared/MainLayout.razor
@@ -125,7 +125,13 @@
 
     async Task DialogSearch()
     {
-        DialogOptions maxWidth = new DialogOptions() { MaxWidth = MaxWidth.Medium, FullWidth = true, Position = DialogPosition.TopCenter };
+        DialogOptions maxWidth = new DialogOptions() 
+        { 
+            MaxWidth = MaxWidth.Medium, 
+            FullWidth = true, 
+            Position = DialogPosition.TopCenter,
+            CloseButton = true
+        };
         var dialog = DialogService.Show<SearchDialog>("Search", maxWidth);
         var result = await dialog.Result;
 


### PR DESCRIPTION
Closes #129 

## Features:
* Fixed icon color on light mode
* Dialog search can now be triggered multiple ways; pressing enter, clicking adornment or clicking search button
* Added autofocus to searchfield
* Added close button

## View
Light mode icon:  
![image](https://user-images.githubusercontent.com/58626043/166146777-e39906d4-c402-49cc-ac6e-0641bcf30fcd.png)

Dialog opened: 
![image](https://user-images.githubusercontent.com/58626043/166146812-7eb277f5-6d4b-482d-96d7-840c6b7d7404.png)
