### PR TITLE
Fix: dotnet value types lower case

### DIFF
--- a/Lexplorer/Components/HomepageOverview.razor
+++ b/Lexplorer/Components/HomepageOverview.razor
@@ -229,8 +229,8 @@
         foreach (var block in blockData!.data!.blocks!)
         {
             transactionCount += block.transactionCount;
-            timeBetweenBlocks.Add(currentTime - Int64.Parse(block.timestamp!));
-            currentTime = Int64.Parse(block.timestamp!);
+            timeBetweenBlocks.Add(currentTime - long.Parse(block.timestamp!));
+            currentTime = long.Parse(block.timestamp!);
         }
         averageTransactions = transactionCount / blockData.data.blocks.Count;
         averageBlockTime = Math.Floor(timeBetweenBlocks.Average() / 60);
@@ -239,7 +239,7 @@
     private void CalculateLastBlockSubmitted()
     {
         long currentTime = DateTimeOffset.Now.ToUnixTimeSeconds();
-        long timeSinceLastBlock = currentTime - Int64.Parse(blockData!.data!.blocks![0].timestamp!);
+        long timeSinceLastBlock = currentTime - long.Parse(blockData!.data!.blocks![0].timestamp!);
         lastBlockSubmittedTime = Math.Floor((double)timeSinceLastBlock / 60);
     }
 

--- a/Lexplorer/Components/L1AccountLink.razor
+++ b/Lexplorer/Components/L1AccountLink.razor
@@ -16,7 +16,7 @@
     {
         get
         {
-            return (shortenAddress) && (address?.Length > 6) ? String.Format("{0}...{1}", address?.Substring(0, 5), address?.Substring(address.Length - 6, 6)) : address;
+            return (shortenAddress) && (address?.Length > 6) ? string.Format("{0}...{1}", address?.Substring(0, 5), address?.Substring(address.Length - 6, 6)) : address;
         }
     }
 }

--- a/Lexplorer/Components/L1TransactionLink.razor
+++ b/Lexplorer/Components/L1TransactionLink.razor
@@ -16,7 +16,7 @@
     {
         get
         {
-            return (shortenHash && (txHash?.Length > 6) )? String.Format("{0}...{1}", txHash?.Substring(0, 5), txHash?.Substring(txHash.Length - 6, 6)) : txHash;
+            return (shortenHash && (txHash?.Length > 6) )? string.Format("{0}...{1}", txHash?.Substring(0, 5), txHash?.Substring(txHash.Length - 6, 6)) : txHash;
         }
     }
 }

--- a/Lexplorer/Components/NFTContent.razor
+++ b/Lexplorer/Components/NFTContent.razor
@@ -63,7 +63,7 @@ else if(hasAnimationContent("html"))
 
     private bool hasAnimationURL()
     {
-        if (String.IsNullOrEmpty(nftMetadata?.animation_url)) return false;
+        if (string.IsNullOrEmpty(nftMetadata?.animation_url)) return false;
         return nftMetadata?.image != nftMetadata?.animation_url;
     }
 

--- a/Lexplorer/Helpers/LinkHelper.cs
+++ b/Lexplorer/Helpers/LinkHelper.cs
@@ -19,12 +19,12 @@
         {
             if (address == null) return new MarkupString();
 
-            String link = (shortenAddress && (address.Length > 6)) ? String.Format("{0}...{1}", address.Substring(0, 5), address.Substring(address.Length - 6, 6)) : address;
+            string link = (shortenAddress && (address.Length > 6)) ? string.Format("{0}...{1}", address.Substring(0, 5), address.Substring(address.Length - 6, 6)) : address;
             if (includeAccountId)
                 link += $" ({id})";
             if ((id != null) && ((ignoreId == null) || (id != ignoreId)))
             {
-                link = String.Format(@"<a Class=""mud-theme-primary"" href=""account/{0}"">{1}</a>", id, link);
+                link = string.Format(@"<a Class=""mud-theme-primary"" href=""account/{0}"">{1}</a>", id, link);
             }
             return new MarkupString(link);
         }

--- a/Lexplorer/Pages/AccountDetails.razor
+++ b/Lexplorer/Pages/AccountDetails.razor
@@ -141,7 +141,7 @@
     {
         get
         {
-            return Int32.TryParse(pageNumber, out int np) ? np : 1;
+            return int.TryParse(pageNumber, out int np) ? np : 1;
         }
         set
         {
@@ -158,7 +158,7 @@
     {
         get
         {
-            return Int32.TryParse(nftPageNumber, out int np) ? np : 1;
+            return int.TryParse(nftPageNumber, out int np) ? np : 1;
         }
         set
         {
@@ -214,7 +214,7 @@
                     balancesLoading = false;
                     StateHasChanged();
                 }
-                if (String.IsNullOrEmpty(pageNumber))
+                if (string.IsNullOrEmpty(pageNumber))
                 {
                     pageNumber = "1";
                 }
@@ -244,7 +244,7 @@
                         string? nftMetadataLink = await AppCache.GetOrAddAsyncNonNull(nftMetadataLinkCacheKey,
                             async () => await EthereumService.GetMetadataLink(slot.nft?.nftID, slot.nft?.token, slot.nft?.nftType),
                             DateTimeOffset.UtcNow.AddHours(1));
-                        if (String.IsNullOrEmpty(nftMetadataLink)) continue;
+                        if (string.IsNullOrEmpty(nftMetadataLink)) continue;
 
                         string nftMetadataCacheKey = $"nftMetadata-{nftMetadataLink}";
                         var nftMetadata = await AppCache.GetOrAddAsyncNonNull(nftMetadataCacheKey,

--- a/Lexplorer/Pages/BlockDetails.razor
+++ b/Lexplorer/Pages/BlockDetails.razor
@@ -93,7 +93,7 @@
     {
         get
         {
-            return Math.Max(1, Int32.Parse(blockNumber ?? "1"));
+            return Math.Max(1, int.Parse(blockNumber ?? "1"));
         }
         set
         {
@@ -105,7 +105,7 @@
     {
         get
         {
-            return Math.Max(1, Int32.Parse(pageNumber ?? "1"));
+            return Math.Max(1, int.Parse(pageNumber ?? "1"));
         }
         set
         {

--- a/Lexplorer/Pages/BlocksOverview.razor
+++ b/Lexplorer/Pages/BlocksOverview.razor
@@ -40,7 +40,7 @@
     {
         get
         {
-            return Math.Max(1, Int32.Parse(pageNumber ?? "1"));
+            return Math.Max(1, int.Parse(pageNumber ?? "1"));
         }
         set
         {

--- a/Lexplorer/Pages/NFTDetail.razor
+++ b/Lexplorer/Pages/NFTDetail.razor
@@ -125,7 +125,7 @@
     {
         get
         {
-            return Int32.Parse(pageNumber ?? "1");
+            return int.Parse(pageNumber ?? "1");
         }
         set
         {
@@ -168,7 +168,7 @@
                     StateHasChanged();
                 }
 
-                if (String.IsNullOrEmpty(pageNumber))
+                if (string.IsNullOrEmpty(pageNumber))
                 {
                     pageNumber = "1";
                 }
@@ -186,12 +186,12 @@
                     string nftMetadataLinkCacheKey = $"nftMetadataLink-{nft?.nftID}";
                     string? nftMetadataLink = await AppCache.GetOrAddAsyncNonNull(nftMetadataLinkCacheKey,
                         async () => await EthereumService.GetMetadataLink(nft?.nftID, nft?.token, nft?.nftType));
-                    if (String.IsNullOrEmpty(nftMetadataLink)) return;
+                    if (string.IsNullOrEmpty(nftMetadataLink)) return;
 
                     string nftMetadataCacheKey = $"nftMetadata-{nftMetadataLink}";
                     nftMetadata = await AppCache.GetOrAddAsyncNonNull(nftMetadataCacheKey,
                         async () => await NftMetadataService.GetMetadata(nftMetadataLink, localCTS.Token));
-                    if (!String.IsNullOrEmpty(nftMetadata?.animation_url))
+                    if (!string.IsNullOrEmpty(nftMetadata?.animation_url))
                     {
                         string nftMetadataContentTypeCacheKey = $"nftMetadata-contentType-{nftMetadataLink}";
                         nftMetadata!.contentType = await AppCache.GetOrAddAsyncNonNull(nftMetadataContentTypeCacheKey,

--- a/Lexplorer/Pages/NFTOverview.razor
+++ b/Lexplorer/Pages/NFTOverview.razor
@@ -36,7 +36,7 @@
     {
         get
         {
-            return Int32.Parse(pageNumber ?? "1");
+            return int.Parse(pageNumber ?? "1");
         }
         set
         {
@@ -59,7 +59,7 @@
     {
         isLoading = true;
 
-        if (String.IsNullOrEmpty(pageNumber))
+        if (string.IsNullOrEmpty(pageNumber))
         {
             pageNumber = "1";
         }

--- a/Lexplorer/Pages/PairsOverview.razor
+++ b/Lexplorer/Pages/PairsOverview.razor
@@ -71,13 +71,13 @@ else
 
     protected override async Task OnParametersSetAsync()
     {
-        if (String.IsNullOrEmpty(pageNumber))
+        if (string.IsNullOrEmpty(pageNumber))
         {
             pageNumber = "0";
         }
         isLoading = true;
         string pairsCacheKey = $"pairsOverview-pairs-page{pageNumber}";
-        pairsData = await AppCache.GetOrAddAsyncNonNull(pairsCacheKey, async () => await LoopringGraphQLService.GetPairs(Int32.Parse(pageNumber) * 10), DateTimeOffset.UtcNow.AddHours(1));
+        pairsData = await AppCache.GetOrAddAsyncNonNull(pairsCacheKey, async () => await LoopringGraphQLService.GetPairs(int.Parse(pageNumber) * 10), DateTimeOffset.UtcNow.AddHours(1));
         int pairCount = 0;
         foreach (var pair in pairsData!.data!.pairs!)
         {
@@ -101,14 +101,14 @@ else
 
     private void GoToNextPage()
     {
-        int nextPage = Int32.Parse(pageNumber) + 1;
+        int nextPage = int.Parse(pageNumber) + 1;
         string parameters = $"pairs?pageNumber={nextPage.ToString()}";
         NavigationManager.NavigateTo(parameters);
     }
 
     private void GoToPreviousPage()
     {
-        int previousPage = Int32.Parse(pageNumber) - 1;
+        int previousPage = int.Parse(pageNumber) - 1;
         string parameters = $"pairs?pageNumber={previousPage.ToString()}";
         NavigationManager.NavigateTo(parameters);
     }

--- a/Lexplorer/Pages/TransactionsOverview.razor
+++ b/Lexplorer/Pages/TransactionsOverview.razor
@@ -49,7 +49,7 @@
     {
         get
         {
-            return Int32.Parse(pageNumber ?? "1");
+            return int.Parse(pageNumber ?? "1");
         }
         set
         {
@@ -91,7 +91,7 @@
     {
         isLoading = true;
 
-        if (String.IsNullOrEmpty(pageNumber))
+        if (string.IsNullOrEmpty(pageNumber))
         {
             pageNumber = "1";
         }

--- a/Lexplorer/Shared/MainLayout.razor
+++ b/Lexplorer/Shared/MainLayout.razor
@@ -56,7 +56,7 @@
     bool _drawerOpen = true;
 
     private IList<object>? searchResults;
-    private Boolean searching = false;
+    private bool searching = false;
     private string? _searchTerm;
     private string? searchTerm
     {
@@ -103,7 +103,7 @@
         if (searchTerm.Contains(".eth", StringComparison.InvariantCultureIgnoreCase))
         {
             string? hexAddress = await EthereumService.GetEthAddressFromEns(searchTerm);
-            if (String.IsNullOrEmpty(hexAddress))
+            if (string.IsNullOrEmpty(hexAddress))
             {
                 searching = false; //nothing found
                 StateHasChanged();

--- a/Lexplorer/Shared/NavMenu.razor
+++ b/Lexplorer/Shared/NavMenu.razor
@@ -5,7 +5,4 @@
     <MudNavLink Href="/account" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.VerifiedUser">Accounts</MudNavLink>
     <MudNavLink Href="/pairs" Match="NavLinkMatch.Prefix" Icon="@Icons.Filled.PeopleOutline">Pairs</MudNavLink>
     <MudNavLink Href="/nfts" Match="NavLinkMatch.Prefix" Icon="@Icons.Filled.MonochromePhotos">NFTs</MudNavLink>
-
-    <!-- <MudNavLink Href="/counter" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Add">Counter</MudNavLink>
-    <MudNavLink Href="/fetchdata" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.List">Fetch data</MudNavLink> -->
 </MudNavMenu>

--- a/Shared/Helpers/TimestampConverter.cs
+++ b/Shared/Helpers/TimestampConverter.cs
@@ -17,10 +17,10 @@ namespace Lexplorer.Helpers
             if (unixTimeStamp == null) return null;
             // Unix timestamp is seconds past epoch
             DateTime dateTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
-            return dateTime.AddSeconds(Double.Parse(unixTimeStamp)).ToLocalTime().ToUniversalTime();
+            return dateTime.AddSeconds(double.Parse(unixTimeStamp)).ToLocalTime().ToUniversalTime();
         }
 
-        public static Double? ToTimeStamp(DateTime? dateTimeUTC)
+        public static double? ToTimeStamp(DateTime? dateTimeUTC)
         {
             if (dateTimeUTC == null) return null;
             return ((DateTimeOffset)dateTimeUTC).ToUnixTimeSeconds();

--- a/Shared/Helpers/TokenAmountConverter.cs
+++ b/Shared/Helpers/TokenAmountConverter.cs
@@ -8,13 +8,13 @@ namespace Lexplorer.Helpers
         //maybe some day use clients Culture? for now invariant
         public static CultureInfo Culture = CultureInfo.InvariantCulture;
 
-        public static decimal ToDecimal(Double? balance, int? decimals, decimal conversionRate = 1)
+        public static decimal ToDecimal(double? balance, int? decimals, decimal conversionRate = 1)
         {
             if (balance == null) return 0;
             return (decimal)(((decimals ?? 0) > 0) ? balance / Math.Pow(10, (double)decimals!) : balance) * conversionRate;
         }
 
-        public static string ToString(Double? balance, int? decimals, decimal conversionRate = 1)
+        public static string ToString(double? balance, int? decimals, decimal conversionRate = 1)
         {
             if (balance == null) return "";
 

--- a/Shared/Models/LoopringV3.cs
+++ b/Shared/Models/LoopringV3.cs
@@ -23,33 +23,33 @@ namespace Lexplorer.Models
     {
         [JsonProperty("__typename")]
         public string? typeName { get; set; }
-        public Int64 accountUpdateCount { get; set; }
-        public Int64 addCount { get; set; }
-        public Int64 ammUpdateCount { get; set; }
+        public long accountUpdateCount { get; set; }
+        public long addCount { get; set; }
+        public long ammUpdateCount { get; set; }
         public string? blockHash { get; set; }
         public int blockSize { get; set; }
         public string? data { get; set; }
-        public Int64 depositCount { get; set; }
-        public Double gasLimit { get; set; }
-        public Double gasPrice { get; set; }
-        public Double height { get; set; }
+        public long depositCount { get; set; }
+        public double gasLimit { get; set; }
+        public double gasPrice { get; set; }
+        public double height { get; set; }
         public string? id { get; set; }
-        public Int64 nftDataCount { get; set; }
-        public Int64 nftMintCount { get; set; }
+        public long nftDataCount { get; set; }
+        public long nftMintCount { get; set; }
         public Account? operatorAccount { get; set; }
-        public Int64 orderbookTradeCount { get; set; }
-        public Int64 removeCount { get; set; }
-        public Int64 signatureVerificationCount { get; set; }
-        public Int64 swapCount { get; set; }
-        public Int64 swapNFTCount { get; set; }
+        public long orderbookTradeCount { get; set; }
+        public long removeCount { get; set; }
+        public long signatureVerificationCount { get; set; }
+        public long swapCount { get; set; }
+        public long swapNFTCount { get; set; }
         public string? timestamp { get; set; }
-        public Int64 tradeNFTCount { get; set; }
-        public Int64 transactionCount { get; set; }
-        public Int64 transferCount { get; set; }
-        public Int64 transferNFTCount { get; set; }
+        public long tradeNFTCount { get; set; }
+        public long transactionCount { get; set; }
+        public long transferCount { get; set; }
+        public long transferNFTCount { get; set; }
         public string? txHash { get; set; }
-        public Int64 withdrawalCount { get; set; }
-        public Int64 withdrawalNFTCount { get; set; }
+        public long withdrawalCount { get; set; }
+        public long withdrawalNFTCount { get; set; }
     }
 
     public class BlockData
@@ -75,25 +75,25 @@ namespace Lexplorer.Models
     }
     public class Proxy
     {
-        public Int64 accountUpdateCount { get; set; }
-        public Int64 addCount { get; set; }
-        public Int64 ammUpdateCount { get; set; }
-        public Int64 depositCount { get; set; }
-        public Int64 nftDataCount { get; set; }
-        public Int64 nftMintCount { get; set; }
-        public Int64 orderbookTradeCount { get; set; }
-        public Int64 removeCount { get; set; }
-        public Int64 signatureVerificationCount { get; set; }
-        public Int64 swapCount { get; set; }
-        public Int64 swapNFTCount { get; set; }
-        public Int64 tradeNFTCount { get; set; }
-        public Int64 blockCount { get; set; }
-        public Int64 userCount { get; set; }
-        public Int64 transactionCount { get; set; }
-        public Int64 transferCount { get; set; }
-        public Int64 transferNFTCount { get; set; }
-        public Int64 withdrawalCount { get; set; }
-        public Int64 withdrawalNFTCount { get; set; }
+        public long accountUpdateCount { get; set; }
+        public long addCount { get; set; }
+        public long ammUpdateCount { get; set; }
+        public long depositCount { get; set; }
+        public long nftDataCount { get; set; }
+        public long nftMintCount { get; set; }
+        public long orderbookTradeCount { get; set; }
+        public long removeCount { get; set; }
+        public long signatureVerificationCount { get; set; }
+        public long swapCount { get; set; }
+        public long swapNFTCount { get; set; }
+        public long tradeNFTCount { get; set; }
+        public long blockCount { get; set; }
+        public long userCount { get; set; }
+        public long transactionCount { get; set; }
+        public long transferCount { get; set; }
+        public long transferNFTCount { get; set; }
+        public long withdrawalCount { get; set; }
+        public long withdrawalNFTCount { get; set; }
     }
 
     [JsonConverter(typeof(JsonSubtypes), "__typename")]
@@ -108,7 +108,7 @@ namespace Lexplorer.Models
     }
     public class Pool : Account
     {
-        public Int32? feeBipsAMM { get; set; }
+        public int? feeBipsAMM { get; set; }
     }
     public class Pair
     {
@@ -130,11 +130,11 @@ namespace Lexplorer.Models
 
     public class AccountTokenBalance
     {
-        public Double balance { get; set; }
+        public double balance { get; set; }
         public string? id { get; set; }
         public Token? token { get; set; }
         public Account? account { get; set; }
-        public Double fBalance {
+        public double fBalance {
             get
             {
                 return balance / Math.Pow(10, token!.decimals);
@@ -205,25 +205,25 @@ namespace Lexplorer.Models
         public Pool? pool { get; set; }
         public Token? tokenA { get; set; }
         public Token? tokenB { get; set; }
-        public Double tokenAPrice { get; set; }
-        public Double tokenBPrice { get; set; }
+        public double tokenAPrice { get; set; }
+        public double tokenBPrice { get; set; }
         public Pair? pair { get; set; }
-        public Double fillSA { get; set; }
-        public Double fillSB { get; set; }
+        public double fillSA { get; set; }
+        public double fillSB { get; set; }
         public bool fillAmountBorSA { get; set; }
         public bool fillAmountBorSB { get; set; }
-        public Double fillBA { get; set; }
-        public Double fillBB { get; set; }
-        public Double feeA { get; set; }
-        public Double protocolFeeA { get; set; }
-        public Double feeB { get; set; }
-        public Double protocolFeeB { get; set; }
+        public double fillBA { get; set; }
+        public double fillBB { get; set; }
+        public double feeA { get; set; }
+        public double protocolFeeA { get; set; }
+        public double feeB { get; set; }
+        public double protocolFeeB { get; set; }
     }
     public class Deposit : Transaction
     {
         public Account? toAccount { get; set; }
         public Token? token { get; set; }
-        public Double amount { get; set; }
+        public double amount { get; set; }
     }
 
     public class OrderBookTrade : Transaction
@@ -232,19 +232,19 @@ namespace Lexplorer.Models
         public Account? accountB { get; set; }
         public Token? tokenA { get; set; }
         public Token? tokenB { get; set; }
-        public Double tokenAPrice { get; set; }
-        public Double tokenBPrice { get; set; }
+        public double tokenAPrice { get; set; }
+        public double tokenBPrice { get; set; }
         public Pair? pair { get; set; }
-        public Double fillSA { get; set; }
-        public Double fillSB { get; set; }
+        public double fillSA { get; set; }
+        public double fillSB { get; set; }
         public bool fillAmountBorSA { get; set; }
         public bool fillAmountBorSB { get; set; }
-        public Double fillBA { get; set; }
-        public Double fillBB { get; set; }
-        public Double feeA { get; set; }
-        public Double protocolFeeA { get; set; }
-        public Double feeB { get; set; }
-        public Double protocolFeeB { get; set; }
+        public double fillBA { get; set; }
+        public double fillBB { get; set; }
+        public double feeA { get; set; }
+        public double protocolFeeA { get; set; }
+        public double feeB { get; set; }
+        public double protocolFeeB { get; set; }
     }
 
     public class Withdrawal : Transaction
@@ -253,8 +253,8 @@ namespace Lexplorer.Models
         public Token? token { get; set; }
         public Token? feeToken { get; set; }
         public bool valid { get; set; }
-        public Double amount { get; set; }
-        public Double fee { get; set; }
+        public double amount { get; set; }
+        public double fee { get; set; }
     }
     public class Transfer : Transaction
     {
@@ -262,8 +262,8 @@ namespace Lexplorer.Models
         public Account? toAccount { get; set; }
         public Token? token { get; set; }
         public Token? feeToken { get; set; }
-        public Double amount { get; set; }
-        public Double fee { get; set; }
+        public double amount { get; set; }
+        public double fee { get; set; }
     }
     public class Add : Transaction
     {
@@ -271,8 +271,8 @@ namespace Lexplorer.Models
         public Pool? pool { get; set; }
         public Token? token { get; set; }
         public Token? feeToken { get; set; }
-        public Double fee { get; set; }
-        public Double amount { get; set; }
+        public double fee { get; set; }
+        public double amount { get; set; }
     }
     public class Remove : Transaction
     {
@@ -280,21 +280,21 @@ namespace Lexplorer.Models
         public Pool? pool { get; set; }
         public Token? token { get; set; }
         public Token? feeToken { get; set; }
-        public Double fee { get; set; }
-        public Double amount { get; set; }
+        public double fee { get; set; }
+        public double amount { get; set; }
     }
     public class AmmUpdate : Transaction
     {
         public Pool? pool { get; set; }
-        public Double tokenWeight { get; set; }
-        public String? tokenID { get; set; }
-        public Double balance { get; set; }
+        public double tokenWeight { get; set; }
+        public string? tokenID { get; set; }
+        public double balance { get; set; }
     }
     public class AccountUpdate : Transaction
     {
         public User? user { get; set; }
         public Token? feeToken { get; set; }
-        public Double fee { get; set; }
+        public double fee { get; set; }
         public string? publicKey { get; set; }
         public int? nonce { get; set; }
     }
@@ -317,7 +317,7 @@ namespace Lexplorer.Models
         [JsonProperty("__typename")]
         public string? typeName { get; set; }
         public Account? account { get; set; }
-        public Double balance { get; set; }
+        public double balance { get; set; }
         public Transaction? createdAtTransaction { get; set; }
         public Transaction? lastUpdatedAtTransaction { get; set; }
         public List<Transaction>? transactions { get; set; }
@@ -337,8 +337,8 @@ namespace Lexplorer.Models
         public Account? receiver { get; set; }
         public NonFungibleToken? nft { get; set; }
         public Token? feeToken { get; set; }
-        public Double fee { get; set; }
-        public Double amount { get; set; }
+        public double fee { get; set; }
+        public double amount { get; set; }
         public string? extraData { get; set; }
     }
 
@@ -347,9 +347,9 @@ namespace Lexplorer.Models
         public Account? fromAccount { get; set; }
         public AccountNFTSlot? slot { get; set; }
         public Token? feeToken { get; set; }
-        public Boolean valid { get; set; }
-        public Double amount { get; set; }
-        public Double fee { get; set; }
+        public bool valid { get; set; }
+        public double amount { get; set; }
+        public double fee { get; set; }
     }
 
     public class TransferNFT : TransactionNFT
@@ -359,8 +359,8 @@ namespace Lexplorer.Models
         public AccountNFTSlot? fromSlot { get; set; }
         public AccountNFTSlot? toSlot { get; set; }
         public Token? feeToken { get; set; }
-        public Double amount { get; set; }
-        public Double fee { get; set; }
+        public double amount { get; set; }
+        public double fee { get; set; }
     }
 
     public class TradeNFT : TransactionNFT
@@ -370,15 +370,15 @@ namespace Lexplorer.Models
         public AccountNFTSlot? slotSeller { get; set; }
         public AccountNFTSlot? slotBuyer { get; set; }
         public Token? token { get; set; }
-        public Double realizedNFTPrice { get; set; }
-        public Double fillSA { get; set; }
-        public Double fillSB { get; set; }
-        public Boolean fillAmountBorSA { get; set; }
-        public Boolean fillAmountBorSB { get; set; }
-        public Double fillBA { get; set; }
-        public Double fillBB { get; set; }
-        public Double feeSeller { get; set; }
-        public Double feeBuyer { get; set; }
+        public double realizedNFTPrice { get; set; }
+        public double fillSA { get; set; }
+        public double fillSB { get; set; }
+        public bool fillAmountBorSA { get; set; }
+        public bool fillAmountBorSB { get; set; }
+        public double fillBA { get; set; }
+        public double fillBB { get; set; }
+        public double feeSeller { get; set; }
+        public double feeBuyer { get; set; }
     }
     public class SwapNFT : TransactionNFT
     {
@@ -388,14 +388,14 @@ namespace Lexplorer.Models
         public AccountNFTSlot? slotBSeller { get; set; }
         public AccountNFTSlot? slotABuyer { get; set; }
         public AccountNFTSlot? slotBBuyer { get; set; }
-        public Double fillSA { get; set; }
-        public Double fillSB { get; set; }
-        public Boolean fillAmountBorSA { get; set; }
-        public Boolean fillAmountBorSB { get; set; }
-        public Double fillBA { get; set; }
-        public Double fillBB { get; set; }
-        public Double feeSeller { get; set; }
-        public Double feeBuyer { get; set; }
+        public double fillSA { get; set; }
+        public double fillSB { get; set; }
+        public bool fillAmountBorSA { get; set; }
+        public bool fillAmountBorSB { get; set; }
+        public double fillBA { get; set; }
+        public double fillBB { get; set; }
+        public double feeSeller { get; set; }
+        public double feeBuyer { get; set; }
 
     }
 
@@ -422,15 +422,15 @@ namespace Lexplorer.Models
 
     public class DailyEntity
     {
-        public Double tradedVolumeToken1Swap { get; set; }
-        public Double tradedVolumeToken0Swap { get; set; }
+        public double tradedVolumeToken1Swap { get; set; }
+        public double tradedVolumeToken0Swap { get; set; }
         public string? id { get; set; }
     }
 
     public class WeeklyEntity
     {
-        public Double tradedVolumeToken1Swap { get; set; }
-        public Double tradedVolumeToken0Swap { get; set; }
+        public double tradedVolumeToken1Swap { get; set; }
+        public double tradedVolumeToken0Swap { get; set; }
         public string? id { get; set; }
     }
 

--- a/Shared/Services/LoopringGraphQLService.cs
+++ b/Shared/Services/LoopringGraphQLService.cs
@@ -29,7 +29,7 @@ namespace Lexplorer.Services
         }
 
         public async Task<Blocks?> GetBlocks(int skip, int first, string orderBy = "internalID",
-            string orderDirection = "desc", string? blockTimestamp = null, Boolean gte = true)
+            string orderDirection = "desc", string? blockTimestamp = null, bool gte = true)
         {
             var blocksQuery = @"
             query blocks(
@@ -112,7 +112,7 @@ namespace Lexplorer.Services
             }
         }
 
-        public async Task<Tuple<Double, Double>?> GetBlockDateRange(DateTime startDateUTC, DateTime endDateUTC)
+        public async Task<Tuple<double, double>?> GetBlockDateRange(DateTime startDateUTC, DateTime endDateUTC)
         {
             var blockQuery = @"
             query swap (
@@ -158,7 +158,7 @@ namespace Lexplorer.Services
             {
                 var response = await _client.PostAsync(request);
                 JToken token = JToken.Parse(response.Content!);
-                return new Tuple<Double, Double>(
+                return new Tuple<double, double>(
                     (double)token["data"]!["firstblock"]![0]!["id"]!,
                     (double)token["data"]!["lastblock"]![0]!["id"]!);
             }
@@ -441,7 +441,7 @@ namespace Lexplorer.Services
             {
                 //remove unused parameter to fix "Invalid query" error with non-hosted graph
                 //split and re-join all lines which don't contain the word "whereFilter"
-                transactionsQuery = String.Join(Environment.NewLine,
+                transactionsQuery = string.Join(Environment.NewLine,
                     transactionsQuery.Split(Environment.NewLine).Where(
                         (a) => !(a.Contains("whereFilter"))));
                 request.AddJsonBody(new
@@ -501,10 +501,10 @@ namespace Lexplorer.Services
             //since there is no way to filter for typename in Accounts_filter, we simply
             //query a different entity, i.e. pools instead of accounts
             string typePluralName = "accounts";
-            if (!String.IsNullOrEmpty(typeName))
+            if (!string.IsNullOrEmpty(typeName))
             {
                 //lower case, but first char only
-                typePluralName = Char.ToLower(typeName[0]) + typeName.Substring(1) + "s";
+                typePluralName = char.ToLower(typeName[0]) + typeName.Substring(1) + "s";
                 accountsQuery = accountsQuery.Replace("accounts(", $"{typePluralName}(");
             }
 
@@ -605,7 +605,7 @@ namespace Lexplorer.Services
                 query = balanceQuery,
                 variables = new
                 {
-                    accountId = Int32.Parse(accountId)
+                    accountId = int.Parse(accountId)
                 }
             });
             var response = await _client.PostAsync(request, cancellationToken);
@@ -630,7 +630,7 @@ namespace Lexplorer.Services
         }
 
         public async Task<string?> GetAccountTransactionsResponse(int skip, int first, string accountId,
-            Double? firstBlockId = null, Double? lastBlockId = null, CancellationToken cancellationToken = default)
+            double? firstBlockId = null, double? lastBlockId = null, CancellationToken cancellationToken = default)
         {
             var accountQuery = @"
             query accountTransactions(
@@ -739,7 +739,7 @@ namespace Lexplorer.Services
         }
 
         public async Task<IList<Transaction>?> GetAccountTransactions(int skip, int first, string accountId,
-            Double? firstBlockId = null, Double? lastBlockId = null, CancellationToken cancellationToken = default)
+            double? firstBlockId = null, double? lastBlockId = null, CancellationToken cancellationToken = default)
         {
             try
             {

--- a/xUnitTests/HelperTests/TestTokenAmountConverter.cs
+++ b/xUnitTests/HelperTests/TestTokenAmountConverter.cs
@@ -11,7 +11,7 @@ namespace xUnitTests.HelperTests
 {
     public class TestTokenAmountConverterToDecimal
     {
-        Double x = 12345678;
+        double x = 12345678;
 
         [Fact]
         public void TestToDecimalSimple()
@@ -102,7 +102,7 @@ namespace xUnitTests.HelperTests
 
     public class TestTokenAmountConverterToStringWithExponent
     {
-        Double x = 12345678;
+        double x = 12345678;
 
         [Fact]
         public void TestMillons()

--- a/xUnitTests/LoopringGraphTests/TestAccountTransactions.cs
+++ b/xUnitTests/LoopringGraphTests/TestAccountTransactions.cs
@@ -26,7 +26,7 @@ namespace xUnitTests.LoopringGraphTests
         public TestAccountTransactions(GraphQLTestsFixture fixture)
         {
             this.fixture = fixture;
-            this.service = fixture!.LGS;
+            service = fixture!.LGS;
         }
 
         [Fact]
@@ -90,7 +90,7 @@ namespace xUnitTests.LoopringGraphTests
         internal void EnsureTransactionDateRange(Transaction? transaction)
         {
             Assert.NotNull(transaction);
-            Assert.InRange<DateTime>(transaction!.verifiedAtDateTime!.Value, startDate, endDate);
+            Assert.InRange(transaction!.verifiedAtDateTime!.Value, startDate, endDate);
         }
 
     }

--- a/xUnitTests/LoopringGraphTests/TestBlock.cs
+++ b/xUnitTests/LoopringGraphTests/TestBlock.cs
@@ -19,7 +19,7 @@ namespace xUnitTests.LoopringGraphTests
         public TestBlock(GraphQLTestsFixture fixture)
         {
             this.fixture = fixture;
-            this.service = fixture!.LGS;
+            service = fixture!.LGS;
         }
 
         [Fact]
@@ -41,7 +41,7 @@ namespace xUnitTests.LoopringGraphTests
         [Fact]
         public async void GetBlockDateRange()
         {
-            Tuple<Double, Double>? blockIDs = await service.GetBlockDateRange(
+            Tuple<double, double>? blockIDs = await service.GetBlockDateRange(
                 new DateTime(2022, 2, 20, 0, 0, 0, DateTimeKind.Utc), 
                 new DateTime(2022, 2, 22, 0, 0, 0, DateTimeKind.Utc));
             Assert.NotNull(blockIDs);

--- a/xUnitTests/LoopringGraphTests/TestNFT.cs
+++ b/xUnitTests/LoopringGraphTests/TestNFT.cs
@@ -16,7 +16,7 @@ namespace xUnitTests.LoopringGraphTests
         public TestNFT(GraphQLTestsFixture fixture)
         {
             this.fixture = fixture;
-            this.service = fixture!.LGS;
+            service = fixture!.LGS;
         }
 
         [Fact]

--- a/xUnitTests/LoopringGraphTests/TestPairs.cs
+++ b/xUnitTests/LoopringGraphTests/TestPairs.cs
@@ -17,7 +17,7 @@ namespace xUnitTests.LoopringGraphTests
         public TestPairs(GraphQLTestsFixture fixture)
         {
             this.fixture = fixture;
-            this.service = fixture!.LGS;
+            service = fixture!.LGS;
         }
 
         [Fact]

--- a/xUnitTests/LoopringGraphTests/TestSearch.cs
+++ b/xUnitTests/LoopringGraphTests/TestSearch.cs
@@ -18,7 +18,7 @@ namespace xUnitTests.LoopringGraphTests
         public TestSearch(GraphQLTestsFixture fixture)
         {
             this.fixture = fixture;
-            this.service = fixture!.LGS;
+            service = fixture!.LGS;
         }
 
         [Fact]

--- a/xUnitTests/LoopringGraphTests/TestTransaction.cs
+++ b/xUnitTests/LoopringGraphTests/TestTransaction.cs
@@ -14,7 +14,7 @@ namespace xUnitTests.LoopringGraphTests
         public TestTransaction(GraphQLTestsFixture fixture)
         {
             this.fixture = fixture;
-            this.service = fixture!.LGS;
+            service = fixture!.LGS;
         }
 
         [Fact]
@@ -34,7 +34,7 @@ namespace xUnitTests.LoopringGraphTests
             var transactions = await service.GetTransactions(0, 5, typeName: typeName);
             Assert.NotNull(transactions);
             Assert.NotEmpty(transactions?.data?.transactions);
-            if (!String.IsNullOrEmpty(typeName))
+            if (!string.IsNullOrEmpty(typeName))
             {
                 foreach (var transaction in transactions?.data?.transactions!)
                 {


### PR DESCRIPTION
## Fixes:
* For consistency changed all String, Int32, Int64, Boolean value types and invokaction of methods from classes to c# aliases. 

Some places string was used, other places String was used. Now it's consistent use as of the c# standards.

Tested OK, no functionality has been compromised