### PR TITLE
Fix #134 SearchDialog crash

### DIFF
--- a/Lexplorer/Dialogs/SearchDialog.razor
+++ b/Lexplorer/Dialogs/SearchDialog.razor
@@ -1,7 +1,17 @@
 ﻿<MudDialog>
     <DialogContent>
         <div class="d-flex flex-column py-1">
-            <MudTextField AutoFocus="true" @bind-Value="searchTerm" Label="Searchterm..." Variant="Variant.Outlined" Adornment="Adornment.End" AdornmentIcon="@Icons.Filled.Search" AdornmentColor="Color.Info" OnAdornmentClick="DoDialogSearch" Margin="Margin.Dense" />
+            <MudTextField AutoFocus="true"
+                          @bind-Value="searchTerm"
+                          Immediate="true"
+                          Label="Searchterm..."
+                          Variant="Variant.Outlined"
+                          Adornment="Adornment.End"
+                          AdornmentIcon="@Icons.Filled.Search"
+                          AdornmentColor="Color.Info"
+                          OnAdornmentClick="DoDialogSearch"
+                          OnKeyDown="SearchTermKeyDown"
+                          Margin="Margin.Dense" />
         </div>
     </DialogContent>
     <DialogActions>
@@ -12,13 +22,12 @@
 @code {
     [CascadingParameter] MudDialogInstance? MudDialog { get; set; }
 
-    private string? _searchTerm;
-    private string? searchTerm
+    private string? searchTerm { get; set; }
+
+    private void SearchTermKeyDown(KeyboardEventArgs e)
     {
-        get { return _searchTerm; }
-        set
+        if (e.Code == "Enter" || e.Code == "NumpadEnter")
         {
-            _searchTerm = value;
             DoDialogSearch();
         }
     }


### PR DESCRIPTION
* the property setter was added to make pressing Enter also search
* this resulted in a crash when starting the search with clicking the
  button or adornment icon, probably because that involved a focus
  change which itself invoked the property setter too
* it also made it impossible to cancel, because clicking the close
  button also invoked the property setter
* solution
  * no explicit property setter anymore
  * instead assign OnKeyDown event and call DoDialogSearch from there
   if the key is Enter or NumpadEnter
  * for this to work, the MudTextField needs Immediate=true so the
   bound property is always up to date