### PR TITLE
Fix #138 hide NFT pager only if on page 1

### DIFF
--- a/Lexplorer/Pages/AccountDetails.razor
+++ b/Lexplorer/Pages/AccountDetails.razor
@@ -61,7 +61,7 @@
         <MudTabPanel Text="NFTs">
             @if (((accountNFTSlots?.Count ?? 0) < 1) && (gotoNFTPage == 1))
             {
-                <MudText>No NFTs</MudText>
+                <MudText class="pa-3">No NFTs</MudText>
             }
             else
             {

--- a/Lexplorer/Pages/AccountDetails.razor
+++ b/Lexplorer/Pages/AccountDetails.razor
@@ -59,7 +59,7 @@
             </MudTable>
         </MudTabPanel>
         <MudTabPanel Text="NFTs">
-            @if ((accountNFTSlots?.Count ?? 0) < 1)
+            @if (((accountNFTSlots?.Count ?? 0) < 1) && (gotoNFTPage == 1))
             {
                 <MudText>No NFTs</MudText>
             }


### PR DESCRIPTION
* so user can always go back if somehow ended up on an empty page
* fixes #138

To reproduce with any account (not necessarily if NFTCount is multiple of NFTPageSize): edit URL to go beyond end of NFTs.

Previously: pagers was hidden and "No NFTs" displaced
Now: pager still visible even though no NFTs are shown