### PR TITLE
Fix: NFT title and div small devices

### DIFF
--- a/Lexplorer/Components/NFTContent.razor
+++ b/Lexplorer/Components/NFTContent.razor
@@ -1,12 +1,12 @@
 ﻿
 @if (showImageSource())
 {
-    <img src="@nftMetadata?.imageURL" Width="@width" Height="@height" />
+    <img src="@nftMetadata?.imageURL" class="nft" />
 }
 
 @if (hasAnimationContent("video"))
 {
-    <video width="@width" height="@height" controls>
+    <video class="nft" controls>
         <source src="@nftMetadata?.animationURL">
         Your browser does not support the video tag.
     </video>
@@ -21,22 +21,16 @@ else if (hasAnimationContent("audio"))
 }
 else if (hasAnimationContent("image"))
 {
-    <img src="@nftMetadata?.animationURL" Width="@width" Height="@height" />
+    <img src="@nftMetadata?.animationURL" class="nft" />
 }
 else if (hasAnimationContent("model") || hasAnimationContent("octet-stream"))
 {
-<style>
-        model-viewer {
-            width: @ToPx(width);
-            height: @ToPx(height);
-        }
-</style>
-    <model-viewer bounds="tight" enable-pan autoplay src="@nftMetadata?.animationURL" ar ar-modes="webxr scene-viewer quick-look"
+    <model-viewer class="nft" bounds="tight" enable-pan autoplay src="@nftMetadata?.animationURL" ar ar-modes="webxr scene-viewer quick-look"
                   camera-controls environment-image="neutral" poster="@nftMetadata?.imageURL" shadow-intensity="1"/>
 }
 else if(hasAnimationContent("html"))
 {
-    <iframe allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" frameborder="0" height="100%" sandbox="allow-scripts" src="@nftMetadata?.animationURL" width="100%" style="min-height: @ToPx(height)"></iframe>
+    <iframe class="nft" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" frameborder="0" sandbox="allow-scripts" src="@nftMetadata?.animationURL" style="min-height: @ToPx(height)"></iframe>
 }
 
 

--- a/Lexplorer/Components/NFTContent.razor
+++ b/Lexplorer/Components/NFTContent.razor
@@ -38,17 +38,6 @@ else if(hasAnimationContent("html"))
     [Parameter]
     public NftMetadata? nftMetadata { get; set; }
 
-    [Parameter]
-    public int width { get; set; } = 512;
-
-    [Parameter]
-    public int height { get; set; } = 512;
-
-    private string ToPx(int size)
-    {
-        return size.ToString() + "px";
-    }
-
     private bool showImageSource()
     {
         //we show the image as long as there is no explicit animation URL - except for audio

--- a/Lexplorer/Components/NFTContent.razor
+++ b/Lexplorer/Components/NFTContent.razor
@@ -30,7 +30,7 @@ else if (hasAnimationContent("model") || hasAnimationContent("octet-stream"))
 }
 else if(hasAnimationContent("html"))
 {
-    <iframe class="nft" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" frameborder="0" sandbox="allow-scripts" src="@nftMetadata?.animationURL" style="min-height: @ToPx(height)"></iframe>
+    <iframe class="nft" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" frameborder="0" sandbox="allow-scripts" src="@nftMetadata?.animationURL" ></iframe>
 }
 
 

--- a/Lexplorer/Pages/AccountDetails.razor
+++ b/Lexplorer/Pages/AccountDetails.razor
@@ -10,10 +10,14 @@
 <PageTitle>The Lexplorer - Account</PageTitle>
 <MudContainer Fixed="true" Class="px-0 extra-extra-extra-large">
     <MudSimpleTable Class="mt-3" Dense="true" Striped="true" Bordered="true">
-        <div class="mud-toolbar mud-toolbar-gutters mud-table-toolbar">
-            <MudText Typo="Typo.h6">@account?.typeName #@account?.id</MudText>
-        </div>
         <tbody>
+            <tr>
+                <td colspan="2">
+                    <div class="mud-toolbar mud-toolbar-gutters mud-table-toolbar">
+                        <MudText Typo="Typo.h6">@account?.typeName #@account?.id</MudText>
+                    </div>
+                </td>
+            </tr>
             <tr>
                 <td>L1 Address</td>
                 <td><L1AccountLink address="@account?.address" shortenAddress="false" /></td>

--- a/Lexplorer/Pages/BlockDetails.razor
+++ b/Lexplorer/Pages/BlockDetails.razor
@@ -8,21 +8,25 @@
 
 
 <MudSimpleTable Dense="true" Striped="true" Bordered="true">
-    <div class="mud-toolbar mud-toolbar-gutters mud-table-toolbar">
-        <MudIconButton Icon="@Icons.Filled.FirstPage" Disabled=@(blockId == 1) OnClick="@(() => blockId = 1)" />
-        <MudIconButton Icon="@Icons.Filled.NavigateBefore" Disabled=@(blockId == 1) OnClick="@(() => blockId -= 1)" />
-        <MudText Typo="Typo.h6">Block #@block?.data?.block?.id</MudText>
-        <MudIconButton Icon="@Icons.Filled.NavigateNext" Disabled=@(blockId == (block?.data?.proxy?.blockCount ?? 0)) OnClick="@(() => blockId += 1)" />
-    </div>
-    @if (isBlockLoading)
-    {
+    <tbody>
         <tr>
             <td colspan="2">
-                <MudProgressLinear Color="Color.Primary" Indeterminate="true" Class="my-7" />
+                <div>
+                    <MudIconButton Icon="@Icons.Filled.FirstPage" Disabled=@(blockId == 1) OnClick="@(() => blockId = 1)" />
+                    <MudIconButton Icon="@Icons.Filled.NavigateBefore" Disabled=@(blockId == 1) OnClick="@(() => blockId -= 1)" />
+                    <MudText Typo="Typo.h6" Inline="true">Block #@block?.data?.block?.id</MudText>
+                    <MudIconButton Icon="@Icons.Filled.NavigateNext" Disabled=@(blockId == (block?.data?.proxy?.blockCount ?? 0)) OnClick="@(() => blockId += 1)" />
+                </div>
             </td>
         </tr>
-    }
-    <tbody>
+        @if (isBlockLoading)
+        {
+            <tr>
+                <td colspan="2">
+                    <MudProgressLinear Color="Color.Primary" Indeterminate="true" Class="my-7" />
+                </td>
+            </tr>
+        }
         <tr>
             <td>Block Hash</td>
             <td>@block?.data?.block?.blockHash</td>

--- a/Lexplorer/Pages/NFTDetail.razor
+++ b/Lexplorer/Pages/NFTDetail.razor
@@ -8,9 +8,15 @@
 
 <PageTitle>The Lexplorer - NFT @nft?.nftID </PageTitle>
 
-<MudText Typo="Typo.h6">@(nftMetadata?.name ?? $"NFT {nft?.nftID}")</MudText>
 <MudSimpleTable Dense="true" Striped="true" Bordered="true">
     <tbody >
+        <tr>
+            <td colspan="2">
+                <div class="mud-toolbar mud-toolbar-gutters mud-table-toolbar">
+                    <MudText Typo="Typo.h6">@(nftMetadata?.name ?? $"NFT {nft?.nftID}")</MudText>
+                </div>
+            </td>
+        </tr>
         <tr>
             <td>Description</td>
             <td>@nftMetadata?.description</td>
@@ -72,7 +78,6 @@
         </tr>
     </tbody>
 </MudSimpleTable>
-
 
 <br />
 

--- a/Lexplorer/Pages/NFTDetail.razor
+++ b/Lexplorer/Pages/NFTDetail.razor
@@ -8,72 +8,45 @@
 
 <PageTitle>The Lexplorer - NFT @nft?.nftID </PageTitle>
 
-<MudSimpleTable Dense="true" Striped="true" Bordered="true">
-    <div class="mud-toolbar mud-toolbar-gutters mud-table-toolbar">
-        <MudText Typo="Typo.h6">@(nftMetadata?.name ?? $"NFT {nft?.nftID}")</MudText>
-    </div>
-    <tbody>
-        <tr>
-            <td>Description</td>
-            <td>@nftMetadata?.description</td>
-        </tr>
-        <tr>
-            <td>Royalty percentage</td>
-            <td>@nftMetadata?.royalty_percentage%</td>
-        </tr>
-        <tr>
-            <td>nftID</td>
-            <td>@nft?.nftID</td>
-        </tr>
-        <tr>
-            <td>Minter</td>
-            <td>@LinkHelper.CreateUserLink(nft?.minter, false, true) </td>
-        </tr>
-        <tr>
-            <td>Minted at</td>
-            <td>@LinkHelper.GetObjectLink(nft?.mintedAtTransaction) </td>
-        </tr>
-        <tr>
-            <td>Token address</td>
-            <td><L1AccountLink address="@nft?.token" shortenAddress="false" /></td>
-        </tr>
-        <tr>
-            <td>Image URL</td>
-            <td>@nftMetadata?.image</td>
-        </tr>
-        <tr>
-            <td>Animation URL</td>
-            <td>@nftMetadata?.animation_url</td>
-        </tr>
+<MudPaper Class="pa-3">
+    <MudText Typo="Typo.h6">@(nftMetadata?.name ?? $"NFT {nft?.nftID}")</MudText>
+
+    <MudList Clickable="true">
+        <MudListItem Text="@nftMetadata?.description" Icon="@Icons.Material.Filled.Description" />
+        <MudDivider />
+        <MudListItem Text="@nftMetadata?.royalty_percentage.ToString()" Icon="@Icons.Material.Filled.Percent" />
+        <MudDivider />
+        <MudListItem Text="@nft?.nftID" Icon="@Icons.Material.Filled.Numbers" Style="word-break:break-all;"/>
+        <MudDivider />
+        <MudListItem Text="@nft?.minter?.address" Href="@("account/" + nft?.minter?.id)" Icon="@Icons.Material.Filled.Build" Style="word-break:break-all;"/>
+        <MudDivider />
+        <MudListItem Text="@nft?.mintedAtTransaction?.id.ToString()" Href="@("transactions/" + nft?.mintedAtTransaction?.id)" Icon="@Icons.Material.Filled.Traffic" Style="word-break:break-all;"/>
+        <MudDivider />
+        <MudListItem Text="@nft?.token" Icon="@Icons.Material.Filled.Token" Style="word-break:break-all;"/>
+        <MudDivider />
+        <MudListItem Text="@nftMetadata?.image" Icon="@Icons.Material.Filled.Image" Style="word-break:break-all;"/>
+        <MudDivider />
+        <MudListItem Text="@nftMetadata?.animation_url" Icon="@Icons.Material.Filled.Animation" Style="word-break:break-all;"/>
+        <MudDivider />
         @if (nftMetadata?.attributes?.Count > 0)
         {
-            <tr>
-                <td colspan="2">
-                    <MudExpansionPanels>
-                        <MudExpansionPanel Text="Traits">
-                            <MudSimpleTable Dense="true" Striped="true" Bordered="true">
-                                <tbody>
-                                    @foreach (var trait in nftMetadata?.attributes!)
-                                    {
-                                        <tr>
-                                            <td>@trait.trait_type</td>
-                                            <td>@trait.value</td>
-                                        </tr>
-                                    }
-                                </tbody>
-                            </MudSimpleTable>
-                        </MudExpansionPanel>
-                    </MudExpansionPanels>
-                </td>
-            </tr>
+            <MudListItem InitiallyExpanded="false" Text="Traits">
+                <NestedList>
+                    @foreach (var trait in nftMetadata?.attributes!)
+                    {
+                        <MudListItem>
+                            <MudText Typo="Typo.h6">@trait.trait_type</MudText>
+                            @trait.value
+                        </MudListItem>
+                    }
+                </NestedList>
+            </MudListItem>
         }
-        <tr>
-            <td colspan="2">
-                <NFTContent nftMetadata="@nftMetadata" />
-            </td>
-        </tr>
-    </tbody>
-</MudSimpleTable>
+        <MudDivider />
+    </MudList>
+    <NFTContent nftMetadata="@nftMetadata" width="100" />
+</MudPaper>
+
 
 <br />
 

--- a/Lexplorer/Pages/NFTDetail.razor
+++ b/Lexplorer/Pages/NFTDetail.razor
@@ -8,43 +8,70 @@
 
 <PageTitle>The Lexplorer - NFT @nft?.nftID </PageTitle>
 
-<MudPaper Class="pa-3">
-    <MudText Typo="Typo.h6">@(nftMetadata?.name ?? $"NFT {nft?.nftID}")</MudText>
-
-    <MudList Clickable="true">
-        <MudListItem Text="@("Description: " + nftMetadata?.description)" />
-        <MudDivider />
-        <MudListItem Text="@("Roalty: " + nftMetadata?.royalty_percentage.ToString() + "%")" />
-        <MudDivider />
-        <MudListItem Text="@("NFT Id: " + nft?.nftID)" Style="word-break:break-all;"/>
-        <MudDivider />
-        <MudListItem Text="@("Minter: " + nft?.minter?.address)" Href="@("account/" + nft?.minter?.id)" Style="word-break:break-all;"/>
-        <MudDivider />
-        <MudListItem Text="@("Minted at: " + nft?.mintedAtTransaction?.id.ToString())" Href="@("transactions/" + nft?.mintedAtTransaction?.id)" Style="word-break:break-all;"/>
-        <MudDivider />
-        <MudListItem Text="@("Token address: " + nft?.token)" Style="word-break:break-all;"/>
-        <MudDivider />
-        <MudListItem Text="@("Image URL: " + nftMetadata?.image)" Style="word-break:break-all;"/>
-        <MudDivider />
-        <MudListItem Text="@("Animation URL: " + nftMetadata?.animation_url)" Style="word-break:break-all;"/>
-        <MudDivider />
+<MudText Typo="Typo.h6">@(nftMetadata?.name ?? $"NFT {nft?.nftID}")</MudText>
+<MudSimpleTable Dense="true" Striped="true" Bordered="true">
+    <tbody >
+        <tr>
+            <td>Description</td>
+            <td>@nftMetadata?.description</td>
+        </tr>
+        <tr>
+            <td>Royalty percentage</td>
+            <td>@nftMetadata?.royalty_percentage%</td>
+        </tr>
+        <tr>
+            <td>nftID</td>
+            <td Style="word-break:break-all;">@nft?.nftID</td>
+        </tr>
+        <tr>
+            <td>Minter</td>
+            <td Style="word-break:break-all;">@LinkHelper.CreateUserLink(nft?.minter, false, true) </td>
+        </tr>
+        <tr>
+            <td>Minted at</td>
+            <td Style="word-break:break-all;">@LinkHelper.GetObjectLink(nft?.mintedAtTransaction) </td>
+        </tr>
+        <tr>
+            <td>Token address</td>
+            <td Style="word-break:break-all;"><L1AccountLink address="@nft?.token" shortenAddress="false" /></td>
+        </tr>
+        <tr>
+            <td>Image URL</td>
+            <td Style="word-break:break-all;">@nftMetadata?.image</td>
+        </tr>
+        <tr>
+            <td>Animation URL</td>
+            <td Style="word-break:break-all;">@nftMetadata?.animation_url</td>
+        </tr>
         @if (nftMetadata?.attributes?.Count > 0)
         {
-            <MudListItem InitiallyExpanded="false" Text="Traits">
-                <NestedList>
-                    @foreach (var trait in nftMetadata?.attributes!)
-                    {
-                        <MudListItem>
-                            <MudText Typo="Typo.inherit">@trait.trait_type => @trait.value</MudText>
-                        </MudListItem>
-                    }
-                </NestedList>
-            </MudListItem>
+            <tr>
+                <td colspan="2">
+                    <MudExpansionPanels>
+                        <MudExpansionPanel Text="Traits">
+                            <MudSimpleTable Dense="true" Striped="true" Bordered="true">
+                                <tbody>
+                                    @foreach (var trait in nftMetadata?.attributes!)
+                                    {
+                                        <tr>
+                                            <td>@trait.trait_type</td>
+                                            <td>@trait.value</td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </MudSimpleTable>
+                        </MudExpansionPanel>
+                    </MudExpansionPanels>
+                </td>
+            </tr>
         }
-        <MudDivider />
-    </MudList>
-    <NFTContent nftMetadata="@nftMetadata" width="100" />
-</MudPaper>
+        <tr>
+            <td colspan="2">
+                <NFTContent nftMetadata="@nftMetadata" />
+            </td>
+        </tr>
+    </tbody>
+</MudSimpleTable>
 
 
 <br />

--- a/Lexplorer/Pages/NFTDetail.razor
+++ b/Lexplorer/Pages/NFTDetail.razor
@@ -12,21 +12,21 @@
     <MudText Typo="Typo.h6">@(nftMetadata?.name ?? $"NFT {nft?.nftID}")</MudText>
 
     <MudList Clickable="true">
-        <MudListItem Text="@nftMetadata?.description" Icon="@Icons.Material.Filled.Description" />
+        <MudListItem Text="@("Description: " + nftMetadata?.description)" />
         <MudDivider />
-        <MudListItem Text="@nftMetadata?.royalty_percentage.ToString()" Icon="@Icons.Material.Filled.Percent" />
+        <MudListItem Text="@("Roalty: " + nftMetadata?.royalty_percentage.ToString() + "%")" />
         <MudDivider />
-        <MudListItem Text="@nft?.nftID" Icon="@Icons.Material.Filled.Numbers" Style="word-break:break-all;"/>
+        <MudListItem Text="@("NFT Id: " + nft?.nftID)" Style="word-break:break-all;"/>
         <MudDivider />
-        <MudListItem Text="@nft?.minter?.address" Href="@("account/" + nft?.minter?.id)" Icon="@Icons.Material.Filled.Build" Style="word-break:break-all;"/>
+        <MudListItem Text="@("Minter: " + nft?.minter?.address)" Href="@("account/" + nft?.minter?.id)" Style="word-break:break-all;"/>
         <MudDivider />
-        <MudListItem Text="@nft?.mintedAtTransaction?.id.ToString()" Href="@("transactions/" + nft?.mintedAtTransaction?.id)" Icon="@Icons.Material.Filled.Traffic" Style="word-break:break-all;"/>
+        <MudListItem Text="@("Minted at: " + nft?.mintedAtTransaction?.id.ToString())" Href="@("transactions/" + nft?.mintedAtTransaction?.id)" Style="word-break:break-all;"/>
         <MudDivider />
-        <MudListItem Text="@nft?.token" Icon="@Icons.Material.Filled.Token" Style="word-break:break-all;"/>
+        <MudListItem Text="@("Token address: " + nft?.token)" Style="word-break:break-all;"/>
         <MudDivider />
-        <MudListItem Text="@nftMetadata?.image" Icon="@Icons.Material.Filled.Image" Style="word-break:break-all;"/>
+        <MudListItem Text="@("Image URL: " + nftMetadata?.image)" Style="word-break:break-all;"/>
         <MudDivider />
-        <MudListItem Text="@nftMetadata?.animation_url" Icon="@Icons.Material.Filled.Animation" Style="word-break:break-all;"/>
+        <MudListItem Text="@("Animation URL: " + nftMetadata?.animation_url)" Style="word-break:break-all;"/>
         <MudDivider />
         @if (nftMetadata?.attributes?.Count > 0)
         {
@@ -35,8 +35,7 @@
                     @foreach (var trait in nftMetadata?.attributes!)
                     {
                         <MudListItem>
-                            <MudText Typo="Typo.h6">@trait.trait_type</MudText>
-                            @trait.value
+                            <MudText Typo="Typo.inherit">@trait.trait_type => @trait.value</MudText>
                         </MudListItem>
                     }
                 </NestedList>

--- a/Lexplorer/Pages/PairsDetail.razor
+++ b/Lexplorer/Pages/PairsDetail.razor
@@ -11,9 +11,15 @@
 
 <PageTitle>The Lexplorer - pair @(pair?.token0?.symbol) / @(pair?.token1?.symbol) </PageTitle>
 
-<MudText Typo="Typo.h6">Pair  @pair?.token0?.symbol / @pair?.token1?.symbol</MudText>
-<MudSimpleTable Dense="true">
+<MudSimpleTable Dense="true" Striped="true" Bordered="true">
     <tbody>
+        <tr>
+            <td colspan="3">
+                <div class="mud-toolbar mud-toolbar-gutters mud-table-toolbar">
+                    <MudText Typo="Typo.h6">Pair  @pair?.token0?.symbol / @pair?.token1?.symbol</MudText>
+                </div>
+            </td>
+        </tr>
         <tr>
             <td>Details</td>
             <td>Token 1</td>

--- a/Lexplorer/Pages/TransactionDetail.razor
+++ b/Lexplorer/Pages/TransactionDetail.razor
@@ -4,9 +4,15 @@
 
 <PageTitle>The Lexplorer - @(transaction?.typeName ?? "Transaction") #@transactionId </PageTitle>
 
-<MudText Typo="Typo.h6">@(transaction?.typeName ?? "Transaction") #@transactionId</MudText>
-<MudSimpleTable Dense="true">
+<MudSimpleTable Dense="true" Striped="true" Bordered="true">
     <tbody>
+        <tr>
+            <td colspan="3">
+                <div class="mud-toolbar mud-toolbar-gutters mud-table-toolbar">
+                    <MudText Typo="Typo.h6">@(transaction?.typeName ?? "Transaction") #@transactionId</MudText>
+                </div>
+            </td>
+        </tr>
         <tr>
             <td>Block #</td>
             <td>@LinkHelper.GetObjectLink(transaction?.block)</td>

--- a/Lexplorer/wwwroot/app.css
+++ b/Lexplorer/wwwroot/app.css
@@ -36,3 +36,51 @@
         max-width: 320px;
     }
 }
+
+img.nft {
+    width: 30%;
+    height: 30%;
+}
+@media screen and (max-width: 600px){
+    img.nft {
+        width: 100%;
+        height: 100%;
+    }
+}
+video.nft {
+    width: 30%;
+    height: 30%;
+}
+
+@media screen and (max-width: 600px) {
+    video.nft {
+        width: 100%;
+        height: 100%;
+    }
+}
+
+model-viewer.nft {
+    width: 450px;
+    height: 450px;
+}
+
+@media screen and (max-width: 600px) {
+    model-viewer.nft {
+        max-width: 100%;
+        max-height: 100%;
+    }
+}
+
+iframe.nft {
+    width: 100%;
+    height: 100%;
+}
+
+@media screen and (max-width: 600px) {
+    iframe.nft {
+        width: 100%;
+        height: 100%;
+        max-width: 100%;
+        max-height: 100%;
+    }
+}

--- a/Lexplorer/wwwroot/app.css
+++ b/Lexplorer/wwwroot/app.css
@@ -74,6 +74,7 @@ model-viewer.nft {
 iframe.nft {
     width: 100%;
     height: 100%;
+    min-height: 512px;
 }
 
 @media screen and (max-width: 600px) {
@@ -82,5 +83,6 @@ iframe.nft {
         height: 100%;
         max-width: 100%;
         max-height: 100%;
+        min-height: 512px;
     }
 }


### PR DESCRIPTION
Closes #145

## Fix:
* NFT Title not showing correctly on smaller devices

## Feature: 
* Added new css classes for usage on nft types showing
* NFT's now displaying at a set heigth and width of 100% for smaller devices. (iFrame nfts not perfectly enhanced)

## View:
### Large devices:
<img src="https://user-images.githubusercontent.com/58626043/167309643-bac9fccf-545a-4139-ba51-f1e1bbe6f862.png" data-canonical-src="https://user-images.githubusercontent.com/58626043/167309643-bac9fccf-545a-4139-ba51-f1e1bbe6f862.png" width="30%" height="30%" />

### Medium devices:
<img src="https://user-images.githubusercontent.com/58626043/167309671-b43bf601-aa7c-4553-bae9-76265a123693.png" data-canonical-src="https://user-images.githubusercontent.com/58626043/167309671-b43bf601-aa7c-4553-bae9-76265a123693.png" width="30%" height="30%" />

### Small devices:
<img src="https://user-images.githubusercontent.com/58626043/167309688-19c56917-b1ff-499d-be04-95cf436a71d1.png" data-canonical-src="https://user-images.githubusercontent.com/58626043/167309688-19c56917-b1ff-499d-be04-95cf436a71d1.png" width="30%" height="30%" />


### GIFS
<img src="https://user-images.githubusercontent.com/58626043/167309718-7de3cc3e-a170-45a2-9d55-680f5b5dee13.png" data-canonical-src="https://user-images.githubusercontent.com/58626043/167309718-7de3cc3e-a170-45a2-9d55-680f5b5dee13.png" width="30%" height="30%" />

### 3D
<img src="https://user-images.githubusercontent.com/58626043/167309738-18c4cc54-596f-43a3-beb4-16c1c171d16a.png" data-canonical-src="https://user-images.githubusercontent.com/58626043/167309738-18c4cc54-596f-43a3-beb4-16c1c171d16a.png" width="30%" height="30%" />

### Video
<img src="https://user-images.githubusercontent.com/58626043/167309754-0caf7923-0120-4511-b28e-adc1b3a70735.png" data-canonical-src="https://user-images.githubusercontent.com/58626043/167309754-0caf7923-0120-4511-b28e-adc1b3a70735.png" width="30%" height="30%" />

