### PR TITLE
Fix Pairs overview table #151

### DIFF
--- a/Lexplorer/Components/HomepageOverview.razor
+++ b/Lexplorer/Components/HomepageOverview.razor
@@ -157,7 +157,6 @@
                 <HeaderContent>
                     <MudTh>Pair</MudTh>
                     <MudTh Style="text-align:right">Volume 24H</MudTh>
-                    <MudTh Style="text-align:right">24H % avg</MudTh>
                     <MudTh Style="text-align:right">Volume 7D</MudTh>
                 </HeaderContent>
                 <RowTemplate>

--- a/Lexplorer/Components/PairsTableDetails.razor
+++ b/Lexplorer/Components/PairsTableDetails.razor
@@ -3,7 +3,6 @@
 
 <MudTd DataLabel="Pair">@LinkHelper.GetObjectLink(pair)</MudTd>
 <MudTd Style="text-align:right" DataLabel="Volume 24H">@getVolume(false)</MudTd>
-<MudTd Style="text-align:right" DataLabel="24H % avg">@get24hPercentage() %</MudTd>
 <MudTd Style="text-align:right" DataLabel="Volume 7D">@getVolume(true)</MudTd>
 
 @code {
@@ -27,12 +26,6 @@
         {
             return $"{TokenAmountConverter.ToStringWithExponent(volume.Value, pair!.token1.decimals, 1)} {pair.token1.symbol}";
         }
-    }
-
-    private string? get24hPercentage()
-    {
-        if (pair == null) return null;
-        return (pair.dailyEntities![0].tradedVolumeToken1 * 7 / pair.weeklyEntities![0].tradedVolumeToken1 * 100).ToString("N2");
     }
 
 }

--- a/Lexplorer/Pages/PairsOverview.razor
+++ b/Lexplorer/Pages/PairsOverview.razor
@@ -20,7 +20,6 @@
     <HeaderContent>
         <MudTh>Pair</MudTh>
         <MudTh Style="text-align:right">Volume 24H</MudTh>
-        <MudTh Style="text-align:right">24H % avg</MudTh>
         <MudTh Style="text-align:right">Volume 7D</MudTh>
     </HeaderContent>
     <RowTemplate>

--- a/Shared/Services/LoopringGraphQLService.cs
+++ b/Shared/Services/LoopringGraphQLService.cs
@@ -842,7 +842,7 @@ namespace Lexplorer.Services
                   token1 {
                     ...TokenFragment
                   }
-                  dailyEntities(skip: 1, first: 1, orderBy: dayEnd, orderDirection: desc) {
+                  dailyEntities(skip: 0, first: 1, orderBy: dayEnd, orderDirection: desc) {
                     id
                     tradedVolumeToken0
                     tradedVolumeToken1


### PR DESCRIPTION
* no longer query yesterday versus currently running week, i.e. no longer skip 1 when querying daily data as described in #151 
* remove volume percentage as calculation didn't make sense considering both 7D and 24H volume are still being filled up