### PR TITLE
Add NFT type name instead of just the number

### DIFF
--- a/Lexplorer/Pages/NFTDetail.razor
+++ b/Lexplorer/Pages/NFTDetail.razor
@@ -9,7 +9,7 @@
 <PageTitle>The Lexplorer - NFT @nft?.nftID </PageTitle>
 
 <MudSimpleTable Dense="true" Striped="true" Bordered="true">
-    <tbody >
+    <tbody>
         <tr>
             <td colspan="2">
                 <div class="mud-toolbar mud-toolbar-gutters mud-table-toolbar">
@@ -20,6 +20,10 @@
         <tr>
             <td>Description</td>
             <td>@nftMetadata?.description</td>
+        </tr>
+        <tr>
+            <td>NFT type</td>
+            <td>@nft?.nftTypeName</td>
         </tr>
         <tr>
             <td>Royalty percentage</td>

--- a/Lexplorer/Pages/TransactionDetail.razor
+++ b/Lexplorer/Pages/TransactionDetail.razor
@@ -242,7 +242,7 @@
                 <td colspan="2">@TokenAmountConverter.ToString(mintNFT.fee, mintNFT.feeToken?.decimals) @mintNFT.feeToken?.symbol</td>
             </tr>
             <tr>
-                <td>NFT type @mintNFT.nft?.nftType</td>
+                <td>NFT type @mintNFT.nft?.nftTypeName</td>
                 <td colspan="2">@LinkHelper.GetObjectLink(@mintNFT.nft)</td>
             </tr>
         }
@@ -269,7 +269,7 @@
             @foreach ((NonFungibleToken nft, int index) in transferNFT.nfts?.WithIndex()!)
             {
                 <tr>
-                    <td>NFT @(index + 1) type @nft.nftType</td>
+                    <td>NFT @(index + 1) type @nft.nftTypeName</td>
                     <td colspan="2">@LinkHelper.GetObjectLink(@nft)</td>
                 </tr>
             }
@@ -297,7 +297,7 @@
             @foreach ((NonFungibleToken nft, int index) in withdrawalNFT.nfts?.WithIndex()!)
             {
                 <tr>
-                    <td>NFT @(index + 1) type @nft.nftType</td>
+                    <td>NFT @(index + 1) type @nft.nftTypeName</td>
                     <td colspan="2">@LinkHelper.GetObjectLink(@nft)</td>
                 </tr>
             }
@@ -349,7 +349,7 @@
             @foreach ((NonFungibleToken nft, int index) in tradeNFT.nfts?.WithIndex()!)
             {
                 <tr>
-                    <td>NFT @(index + 1) type @nft.nftType</td>
+                    <td>NFT @(index + 1) type @nft.nftTypeName</td>
                     <td colspan="2">@LinkHelper.GetObjectLink(@nft)</td>
                 </tr>
             }

--- a/Shared/Models/LoopringV3.cs
+++ b/Shared/Models/LoopringV3.cs
@@ -316,6 +316,21 @@ namespace Lexplorer.Models
         public string? token { get; set; }
         public string? nftID { get; set; }
         public int nftType { get; set; }
+        public string nftTypeName
+        {
+            get
+            {
+                switch (nftType)
+                {
+                    case 0:
+                        return "ERC1155";
+                    case 1:
+                        return "ERC721";
+                    default:
+                        return "unknown";
+                }
+            }
+        }
         public List<AccountNFTSlot>? slots { get; set; }
         public List<TransactionNFT>? transactions { get; set; }
     }


### PR DESCRIPTION
* took meaning 0 = ERC1155 and 1 = ERC721 from readme in
  LoopmintSharp
* new row in NFTDetail
* updated in transaction details showing type name instead of type