### PR TITLE
Fix #108 allow sound for html NFTs

### DIFF
--- a/Lexplorer/Components/NFTContent.razor
+++ b/Lexplorer/Components/NFTContent.razor
@@ -30,7 +30,7 @@ else if (hasAnimationContent("model") || hasAnimationContent("octet-stream"))
 }
 else if(hasAnimationContent("html"))
 {
-    <iframe class="nft" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" frameborder="0" sandbox="allow-scripts" src="@nftMetadata?.animationURL" ></iframe>
+    <iframe class="nft" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" frameborder="0" sandbox="allow-scripts allow-same-origin" src="@nftMetadata?.animationURL" ></iframe>
 }
 
 


### PR DESCRIPTION
@fudgebucket27 this should fix issue #108. The problem was not related to allowing sound but good ol' CORS.. 🤞

Console error from the example NFT in #108:
`Access to XMLHttpRequest at 'https://fudgey.mypinata.cloud/ipfs/QmX5Bxv77TPDwMH4k3vfrB8KnwWbVP43fP9Pa4EzGLi92Y/sounds/hoowav.mp3?1650209195009' from origin 'null' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: It does not have HTTP ok status.`