### PR TITLE
Fixing #153 with skewed images in Safari (macOS and iOS)

### DIFF
--- a/Lexplorer/wwwroot/app.css
+++ b/Lexplorer/wwwroot/app.css
@@ -39,12 +39,10 @@
 
 img.nft {
     width: 30%;
-    height: 30%;
 }
 @media screen and (max-width: 600px){
     img.nft {
         width: 100%;
-        height: 100%;
     }
 }
 video.nft {


### PR DESCRIPTION
* tried with height: auto first, but what's the actual point compared
  to omitting height completely?
* only happened with Safari because the img was in a table
* now removing height all-together, for smaller size devices too