### PR TITLE
Fix #160 change IPFS links to loopring pinata

### DIFF
--- a/Lexplorer/Components/NFTContent.razor
+++ b/Lexplorer/Components/NFTContent.razor
@@ -1,13 +1,14 @@
-﻿
+﻿@inject NftMetadataService NftMetadataService;
+
 @if (showImageSource())
 {
-    <img src="@nftMetadata?.imageURL" class="nft" />
+    <img src="@NftMetadataService.MakeIPFSLink(nftMetadata?.image)" class="nft" />
 }
 
 @if (hasAnimationContent("video"))
 {
     <video class="nft" controls>
-        <source src="@nftMetadata?.animationURL">
+        <source src="@NftMetadataService.MakeIPFSLink(nftMetadata?.animation_url)">
         Your browser does not support the video tag.
     </video>
 }
@@ -15,22 +16,24 @@ else if (hasAnimationContent("audio"))
 {
     <br />
     <audio controls>
-        <source src="@nftMetadata?.animationURL">
+        <source src="@NftMetadataService.MakeIPFSLink(nftMetadata?.animation_url)">
         Your browser does not support the audio element.
     </audio>
 }
 else if (hasAnimationContent("image"))
 {
-    <img src="@nftMetadata?.animationURL" class="nft" />
+    <img src="@NftMetadataService.MakeIPFSLink(nftMetadata?.animation_url)" class="nft" />
 }
 else if (hasAnimationContent("model") || hasAnimationContent("octet-stream"))
 {
-    <model-viewer class="nft" bounds="tight" enable-pan autoplay src="@nftMetadata?.animationURL" ar ar-modes="webxr scene-viewer quick-look"
-                  camera-controls environment-image="neutral" poster="@nftMetadata?.imageURL" shadow-intensity="1"/>
+    <model-viewer class="nft" bounds="tight" enable-pan autoplay src="@NftMetadataService.MakeIPFSLink(nftMetadata?.animation_url)"
+                  ar ar-modes="webxr scene-viewer quick-look" camera-controls environment-image="neutral"
+                  poster="@NftMetadataService.MakeIPFSLink(nftMetadata?.image)" shadow-intensity="1" />
 }
-else if(hasAnimationContent("html"))
+else if (hasAnimationContent("html"))
 {
-    <iframe class="nft" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" frameborder="0" sandbox="allow-scripts allow-same-origin" src="@nftMetadata?.animationURL" ></iframe>
+    <iframe class="nft" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" frameborder="0"
+            sandbox="allow-scripts allow-same-origin" src="@NftMetadataService.MakeIPFSLink(nftMetadata?.animation_url)"></iframe>
 }
 
 

--- a/Lexplorer/Pages/AccountDetails.razor
+++ b/Lexplorer/Pages/AccountDetails.razor
@@ -83,7 +83,7 @@
                         var metaData = GetMetadata(slot.nft?.id);
                         <MudItem xs="12" sm="4" md="4" lg="2">
                             <MudCard Style="height:100%;position:relative">
-                                <MudCardMedia Image="@metaData?.imageURL" Style="object-fit:contain" />
+                                <MudCardMedia Image="@NftMetadataService.MakeIPFSLink(metaData?.image)" Style="object-fit:contain" />
                                 <MudCardContent>
                                     <MudText Typo="Typo.h6">@metaData?.name</MudText>
                                     <MudChip Label="true" Color="Color.Primary" Class="ml-0">x @slot.balance.ToString("#,##0")</MudChip>

--- a/Lexplorer/Pages/NFTDetail.razor
+++ b/Lexplorer/Pages/NFTDetail.razor
@@ -203,7 +203,7 @@
                     {
                         string nftMetadataContentTypeCacheKey = $"nftMetadata-contentType-{nftMetadataLink}";
                         nftMetadata!.contentType = await AppCache.GetOrAddAsyncNonNull(nftMetadataContentTypeCacheKey,
-                            async () => await NftMetadataService.GetContentTypeFromURL(nftMetadata.animationURL!, localCTS.Token));
+                            async () => await NftMetadataService.GetContentTypeFromURL(nftMetadata.animation_url!, localCTS.Token));
                     }
                     StateHasChanged();
                 }

--- a/Lexplorer/appsettings.json
+++ b/Lexplorer/appsettings.json
@@ -9,6 +9,9 @@
   "services": {
     "loopstats": {
       "endpoint": "https://loopy.sv2web.no/"
+    },
+    "pinata": {
+      "endpoint": "https://loopring.mypinata.cloud/ipfs/"
     }
   },
   "AllowedHosts": "*"

--- a/Shared/Models/NftMetadata.cs
+++ b/Shared/Models/NftMetadata.cs
@@ -8,30 +8,9 @@ namespace Lexplorer.Models
     {
         public string? description { get; set;}
         public string? image { get; set; }
-        public string? imageURL
-        {
-            get
-            {
-                if (image == null) return null;
-                //remove the ipfs:// when concatenating with mypinata URL
-                return image.StartsWith("ipfs://") ? string.Concat("https://fudgey.mypinata.cloud/ipfs/", image.Remove(0, 7)) : image;
-            }
-        }
         public string? name { get; set; }
         public int royalty_percentage { get; set; }
-
         public string? animation_url { get; set; }
-
-        public string? animationURL
-        {
-            get
-            {
-                if (animation_url == null) return null;
-                //remove the ipfs:// when concatenating with mypinata URL
-                return animation_url.StartsWith("ipfs://") ? string.Concat("https://fudgey.mypinata.cloud/ipfs/", animation_url.Remove(0, 7)) : animation_url;
-            }
-        }
-
         public string? contentType { get; set; }
 
         public List<NftAttribute>? attributes { get; set; }

--- a/xUnitTests/NFTMetaDataTests/BaseNMDTests.cs
+++ b/xUnitTests/NFTMetaDataTests/BaseNMDTests.cs
@@ -13,7 +13,7 @@ namespace xUnitTests.NFTMetaDataTests
 
         public NFTMetaDataTestsFixture()
         {
-            NMS = new NftMetadataService();
+            NMS = new NftMetadataService("https://loopring.mypinata.cloud/ipfs/");
             EthS = new EthereumService();
         }
 


### PR DESCRIPTION
* get _ipfsBaseUrl from config - similar to LoopStat service
* refactored MakeIPFSLink so it's publicly availabe
* removed URL helper properties from NFTMetaData
* updated all sites where these properties were used to use the
  services MakeIPFSLink method
* for tests just use a hardcoded URL with overloaded constructor to
  directly provide the base URL