### PR TITLE
Making Loopring graph endpoint configurable via appsettings

### DIFF
--- a/Lexplorer/appsettings.json
+++ b/Lexplorer/appsettings.json
@@ -12,6 +12,9 @@
     },
     "pinata": {
       "endpoint": "https://loopring.mypinata.cloud/ipfs/"
+    },
+    "loopringgraph": {
+      "endpoint": "https://api.thegraph.com/subgraphs/name/juanmardefago/loopring36"
     }
   },
   "AllowedHosts": "*"

--- a/Shared/Services/LoopringGraphQLService.cs
+++ b/Shared/Services/LoopringGraphQLService.cs
@@ -14,18 +14,22 @@ using RestSharp.Serializers;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Threading;
+using Microsoft.Extensions.Configuration;
 
 namespace Lexplorer.Services
 {
     public class LoopringGraphQLService : IDisposable
     {
-        const string _baseUrl = "https://api.thegraph.com/subgraphs/name/juanmardefago/loopring36";
-
         readonly RestClient _client;
 
-        public LoopringGraphQLService()
+        public LoopringGraphQLService(IConfiguration config)
         {
-            _client = new RestClient(_baseUrl);
+            _client = new RestClient(config.GetSection("services:loopringgraph:endpoint").Value);
+        }
+
+        public LoopringGraphQLService(string baseUrl)
+        {
+            _client = new RestClient(baseUrl);
         }
 
         public async Task<Blocks?> GetBlocks(int skip, int first, string orderBy = "internalID",

--- a/xUnitTests/LoopringGraphTests/BaseLGTest.cs
+++ b/xUnitTests/LoopringGraphTests/BaseLGTest.cs
@@ -17,7 +17,7 @@ namespace xUnitTests.LoopringGraphTests
 
         public GraphQLTestsFixture()
         {
-            LGS = new LoopringGraphQLService();
+            LGS = new LoopringGraphQLService("https://api.thegraph.com/subgraphs/name/juanmardefago/loopring36");
         }
 
         public void Dispose()


### PR DESCRIPTION
* Similar to what has already been done for NFT and Loopstats services