### PR TITLE
Support searching for NFT with decimal BigInteger

### DIFF
--- a/xUnitTests/LoopringGraphTests/TestSearch.cs
+++ b/xUnitTests/LoopringGraphTests/TestSearch.cs
@@ -54,12 +54,15 @@ namespace xUnitTests.LoopringGraphTests
         [InlineData("4baf35a6982a81402fbe5882a47a75add97a01cc69fc418b5fc545026751f08a")]
         [InlineData("4BAF35A6982A81402FBE5882A47A75ADD97A01CC69FC418B5FC545026751F08A")]
         [InlineData("0x010a8144e644ace657426f10d35a2a3bee1d098e-0-0xdec45f94c65a79278b7a779a0f5e09a361672e5d-0x4baf35a6982a81402fbe5882a47a75add97a01cc69fc418b5fc545026751f08a-0")]
-        public async void SearchNFT(string nftid)
+        [InlineData("0xbe72937c67b664f306bffe213fe985fee73b9889382aa586b5c87c75018d6f25")]
+        [InlineData("86141879706873913262585335320555568471425816097800752753584697084372491005733", true)]
+        public async void SearchNFT(string nftid, bool skipContainsID = false)
         {
             var searchResult = await service.Search(nftid);
             Assert.NotEmpty(searchResult);
             Assert.IsType<NonFungibleToken>(searchResult![0]);
-            Assert.Contains(nftid, (searchResult![0] as NonFungibleToken)!.id, StringComparison.InvariantCultureIgnoreCase);
+            if (!skipContainsID)
+                Assert.Contains(nftid, (searchResult![0] as NonFungibleToken)!.id, StringComparison.InvariantCultureIgnoreCase);
         }
     }
 }


### PR DESCRIPTION
* test BigInteger.TryParse first and if it succeeds then
  convert to hexadecimal string
* needs leading zeros removed for the graph to find it (no clue why
  .NET even adds them)
* added test cases
  * decimal notation requires that "contains" check is made optional
* fixes #173