### PR TITLE
Feature/view collection

### DIFF
--- a/Lexplorer/Lexplorer.csproj
+++ b/Lexplorer/Lexplorer.csproj
@@ -27,12 +27,6 @@
     <PackageReference Include="Blazor-ApexCharts" Version="0.9.7-beta" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Content Update="appsettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 
 </Project>

--- a/Lexplorer/Lexplorer.csproj
+++ b/Lexplorer/Lexplorer.csproj
@@ -27,6 +27,12 @@
     <PackageReference Include="Blazor-ApexCharts" Version="0.9.7-beta" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Update="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 
 </Project>

--- a/Lexplorer/Lexplorer.csproj
+++ b/Lexplorer/Lexplorer.csproj
@@ -29,7 +29,7 @@
 
   <ItemGroup>
     <Content Update="appsettings.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
 

--- a/Lexplorer/Pages/NFTCollection.razor
+++ b/Lexplorer/Pages/NFTCollection.razor
@@ -20,7 +20,7 @@
                                 MiddleCount="1" 
                                 ShowLastButton="true" 
                                 Selected="@goToPage"
-                                Count="@goToNextPage"
+                                Count="@calculatePageCount"
                                 SelectedChanged="@((int page) => goToPage = page)"/>
                         </MudToolBar>
                         </MudPaper>
@@ -56,7 +56,7 @@
                     MiddleCount="1" 
                     ShowLastButton="true" 
                     Selected="@goToPage"
-                    Count="@goToNextPage"
+                    Count="@calculatePageCount"
                     SelectedChanged="@((int page) => goToPage = page)"/>
                  </MudToolBar>
            </MudPaper>
@@ -87,11 +87,25 @@
         }
     }
 
-    public int goToNextPage
+    public int calculatePageCount
     {
         get
         {
-            return int.TryParse(pageNumber, out int np) ? np + 1 : 1;
+            if(int.TryParse(pageNumber, out int np))
+            {
+                if(collectionNFTSlots.Count < pageSize)
+                {
+                    return np;
+                }
+                else
+                {
+                    return np + 1;
+                }
+            }
+            else
+            {
+                return 1;
+            }
         }
     }
 

--- a/Lexplorer/Pages/NFTCollection.razor
+++ b/Lexplorer/Pages/NFTCollection.razor
@@ -143,13 +143,13 @@
                     StateHasChanged();
                     foreach (var slot in collectionNFTSlots!)
                     {
-                        string nftMetadataLinkCacheKey = $"collection-{tokenAddress}-nftMetadataLink-{slot.nftID}";
+                        string nftMetadataLinkCacheKey = $"nftMetadataLink-{slot.nftID}";
                         string? nftMetadataLink = await AppCache.GetOrAddAsyncNonNull(nftMetadataLinkCacheKey,
                             async () => await EthereumService.GetMetadataLink(slot.nftID, tokenAddress, slot.nftType),
                             DateTimeOffset.UtcNow.AddHours(1));
                         if (string.IsNullOrEmpty(nftMetadataLink)) continue;
 
-                        string nftMetadataCacheKey = $"collection-{tokenAddress}-nftMetadata-{nftMetadataLink}";
+                        string nftMetadataCacheKey = $"nftMetadata-{nftMetadataLink}";
                         var nftMetadata = await AppCache.GetOrAddAsyncNonNull(nftMetadataCacheKey,
                             async () => await NftMetadataService.GetMetadata(nftMetadataLink, localCTS.Token),
                             DateTimeOffset.UtcNow.AddHours(1));

--- a/Lexplorer/Pages/NFTCollection.razor
+++ b/Lexplorer/Pages/NFTCollection.razor
@@ -125,7 +125,7 @@
             cts = localCTS;
             try
             {
-                if (String.IsNullOrEmpty(tokenAddress)) return;
+                if (string.IsNullOrEmpty(tokenAddress)) return;
                 if (string.IsNullOrEmpty(pageNumber))
                 {
                     pageNumber = "1";

--- a/Lexplorer/Pages/NFTCollection.razor
+++ b/Lexplorer/Pages/NFTCollection.razor
@@ -91,21 +91,7 @@
     {
         get
         {
-            if(int.TryParse(pageNumber, out int np))
-            {
-                if(collectionNFTSlots.Count < pageSize)
-                {
-                    return np;
-                }
-                else
-                {
-                    return np + 1;
-                }
-            }
-            else
-            {
-                return 1;
-            }
+            return goToPage + ((collectionNFTSlots?.Count < pageSize) ? 0 : 1);
         }
     }
 
@@ -126,12 +112,8 @@
             try
             {
                 if (string.IsNullOrEmpty(tokenAddress)) return;
-                if (string.IsNullOrEmpty(pageNumber))
-                {
-                    pageNumber = "1";
-                }
 
-                string collectionNftKey = $"collection-{tokenAddress}-page-{pageNumber}";
+                string collectionNftKey = $"collection-{tokenAddress}-page-{goToPage}";
                 collectionNFTSlots = await AppCache.GetOrAddAsyncNonNull(collectionNftKey,
                     async () => await LoopringGraphQLService.GetCollectionNFTs(tokenAddress, (goToPage - 1) * pageSize, cancellationToken: localCTS.Token),
                     DateTimeOffset.UtcNow.AddMinutes(10));

--- a/Lexplorer/Pages/NFTCollection.razor
+++ b/Lexplorer/Pages/NFTCollection.razor
@@ -1,0 +1,174 @@
+﻿@page "/collections/{tokenAddress}"
+@using System.Diagnostics
+@inject LoopringGraphQLService LoopringGraphQLService;
+@inject EthereumService EthereumService;
+@inject NftMetadataService NftMetadataService;
+@inject NavigationManager NavigationManager;
+@inject IAppCache AppCache;
+
+<PageTitle>The Lexplorer - NFT Collection</PageTitle>
+
+<MudContainer Fixed="true" Class="px-0 extra-extra-extra-large">
+    <MudText Typo="Typo.h6">NFT Contract Address <L1AccountLink address="@tokenAddress" shortenAddress="false" /></MudText>
+    <br />
+    <MudGrid>
+        <MudItem xs="12" Class="d-flex justify-center">
+            <MudPaper Width="100%" >
+            <MudToolBar Class="justify-center">
+                <MudPagination Size="Size.Small" ShowFirstButton="true" 
+                                BoundaryCount="1" 
+                                MiddleCount="1" 
+                                ShowLastButton="true" 
+                                Selected="@goToPage"
+                                Count="@goToNextPage"
+                                SelectedChanged="@((int page) => goToPage = page)"/>
+                        </MudToolBar>
+                        </MudPaper>
+                    </MudItem>
+        @if ((collectionNFTSlots != null && collectionNFTSlots.Count > 1))
+        {
+            @foreach (var slot in collectionNFTSlots!)
+            {
+                var metaData = GetMetadata(slot.nftID);
+                <MudItem xs="12" sm="4" md="4" lg="2">
+                    <MudCard Style="height:100%;position:relative" Class="ma-1 border-solid">
+                           <MudCardMedia Image="@NftMetadataService.MakeIPFSLink(metaData?.image)" Style="object-fit:contain" />
+                           <MudCardContent>
+                               <MudText Typo="Typo.h6">@metaData?.name</MudText>
+                               <MudText Typo="Typo.body2">@metaData?.description</MudText>
+                           </MudCardContent>
+                           <MudCardActions>
+                               <MudButton Style="position:absolute;bottom:0;" Variant="Variant.Text" Color="Color.Primary" Link=@LinkHelper.GetObjectLinkAddress(slot)?.Item1>Go to NFT</MudButton>
+                           </MudCardActions>
+                    </MudCard>
+                </MudItem>
+            }
+        }
+        else
+        {
+            <MudText class="pa-3">No NFTs</MudText>
+        }
+        <MudHidden Breakpoint="Breakpoint.MdAndDown" Invert="true">
+            <MudPaper Width="100%" Class="mx-4">
+                <MudToolBar Class="justify-center">
+                    <MudPagination Size="Size.Small" ShowFirstButton="true" 
+                    BoundaryCount="1" 
+                    MiddleCount="1" 
+                    ShowLastButton="true" 
+                    Selected="@goToPage"
+                    Count="@goToNextPage"
+                    SelectedChanged="@((int page) => goToPage = page)"/>
+                 </MudToolBar>
+           </MudPaper>
+       </MudHidden>
+       <MudDivider DividerType="DividerType.Middle" Class="my-6"/>
+    </MudGrid>
+</MudContainer>
+
+@code {
+    [Parameter]
+    public string? tokenAddress { get; set; }
+
+    [Parameter]
+    [SupplyParameterFromQuery]
+    public string pageNumber { get; set; } = "1";
+
+    public int goToPage
+    {
+        get
+        {
+            return int.TryParse(pageNumber, out int np) ? np : 1;
+        }
+        set
+        {
+            pageNumber = value.ToString(); //set immediately for MudPagination to not switch forth and back
+            string URL = $"/collections/{tokenAddress}?pageNumber={value}";
+            NavigationManager.NavigateTo(URL);
+        }
+    }
+
+    public int goToNextPage
+    {
+        get
+        {
+            return int.TryParse(pageNumber, out int np) ? np + 1 : 1;
+        }
+    }
+
+    public readonly int pageSize = 12; //6 per row
+    private CancellationTokenSource? cts;
+    private IList<NonFungibleToken>? collectionNFTSlots { get; set; } = new List<NonFungibleToken>();
+    private Dictionary<string, NftMetadata> NFTdata { get; set; } = new Dictionary<string, NftMetadata>();
+    protected override async Task OnParametersSetAsync()
+    {
+        //cancel any previous OnParametersSetAsync which might still be running
+        cts?.Cancel();
+
+        using (CancellationTokenSource localCTS = new CancellationTokenSource())
+        {
+            //give future calls a chance to cancel us; it is now safe to replace
+            //any previous value of cts, since we already cancelled it above
+            cts = localCTS;
+            try
+            {
+                if (String.IsNullOrEmpty(tokenAddress)) return;
+                if (string.IsNullOrEmpty(pageNumber))
+                {
+                    pageNumber = "1";
+                }
+
+                string collectionNftKey = $"collection-{tokenAddress}-page-{pageNumber}";
+                collectionNFTSlots = await AppCache.GetOrAddAsyncNonNull(collectionNftKey,
+                    async () => await LoopringGraphQLService.GetCollectionNFTs(tokenAddress, (goToPage - 1) * pageSize, cancellationToken: localCTS.Token),
+                    DateTimeOffset.UtcNow.AddMinutes(10));
+                localCTS.Token.ThrowIfCancellationRequested();
+                Dictionary<string, NftMetadata> localNFTdata = new Dictionary<string, NftMetadata>();
+                NFTdata = localNFTdata;
+                if (collectionNFTSlots != null)
+                {
+                    StateHasChanged();
+                    foreach (var slot in collectionNFTSlots!)
+                    {
+                        string nftMetadataLinkCacheKey = $"collection-{tokenAddress}-nftMetadataLink-{slot.nftID}";
+                        string? nftMetadataLink = await AppCache.GetOrAddAsyncNonNull(nftMetadataLinkCacheKey,
+                            async () => await EthereumService.GetMetadataLink(slot.nftID, tokenAddress, slot.nftType),
+                            DateTimeOffset.UtcNow.AddHours(1));
+                        if (string.IsNullOrEmpty(nftMetadataLink)) continue;
+
+                        string nftMetadataCacheKey = $"collection-{tokenAddress}-nftMetadata-{nftMetadataLink}";
+                        var nftMetadata = await AppCache.GetOrAddAsyncNonNull(nftMetadataCacheKey,
+                            async () => await NftMetadataService.GetMetadata(nftMetadataLink, localCTS.Token),
+                            DateTimeOffset.UtcNow.AddHours(1));
+                        localCTS.Token.ThrowIfCancellationRequested();
+                        if (nftMetadata == null) continue;
+
+                        localNFTdata.Add(slot.nftID!, nftMetadata);
+                        StateHasChanged();
+                    }
+                }
+                StateHasChanged();
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (Exception e)
+            {
+                Trace.WriteLine(e.StackTrace + "\n" + e.Message);
+            }
+            //now for cleanup, we must clear cts, but only if it is still our localCTS, which we're about to dispose
+            //otherwise a new call has already replaced cts with it's own localCTS
+            Interlocked.CompareExchange<CancellationTokenSource?>(ref cts, null, localCTS);
+        }
+    }
+
+    private NftMetadata? GetMetadata(string? nftID)
+    {
+        NftMetadata? data = null;
+        if (nftID != null)
+        {
+            NFTdata.TryGetValue(nftID, out data);
+        }
+        return data;
+    }
+
+ }

--- a/Lexplorer/Pages/NFTCollection.razor
+++ b/Lexplorer/Pages/NFTCollection.razor
@@ -1,4 +1,4 @@
-﻿@page "/collections/{tokenAddress}"
+﻿@page "/nfts/collections/{tokenAddress}"
 @using System.Diagnostics
 @inject LoopringGraphQLService LoopringGraphQLService;
 @inject EthereumService EthereumService;
@@ -82,7 +82,7 @@
         set
         {
             pageNumber = value.ToString(); //set immediately for MudPagination to not switch forth and back
-            string URL = $"/collections/{tokenAddress}?pageNumber={value}";
+            string URL = $"/nfts/collections/{tokenAddress}?pageNumber={value}";
             NavigationManager.NavigateTo(URL);
         }
     }

--- a/Lexplorer/Pages/NFTCollection.razor
+++ b/Lexplorer/Pages/NFTCollection.razor
@@ -25,7 +25,7 @@
                         </MudToolBar>
                         </MudPaper>
                     </MudItem>
-        @if ((collectionNFTSlots != null && collectionNFTSlots.Count > 1))
+        @if (collectionNFTSlots != null && collectionNFTSlots.Count > 0)
         {
             @foreach (var slot in collectionNFTSlots!)
             {

--- a/Lexplorer/Pages/NFTDetail.razor
+++ b/Lexplorer/Pages/NFTDetail.razor
@@ -88,9 +88,7 @@
         {
             <tr>
                 <td colspan="2">
-             
-                        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="goToCollectionPage">View collection</MudButton>
-                    }
+                    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="goToCollectionPage">View collection</MudButton>
                 </td>
             </tr>
         }

--- a/Lexplorer/Pages/NFTDetail.razor
+++ b/Lexplorer/Pages/NFTDetail.razor
@@ -84,6 +84,14 @@
                 <NFTContent nftMetadata="@nftMetadata" />
             </td>
         </tr>
+        <tr>
+            <td colspan="2">
+                @if(nft?.token != null)
+                {
+                    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="goToCollectionPage">View collection</MudButton>
+                }
+            </td>
+        </tr>
     </tbody>
 </MudSimpleTable>
 
@@ -225,6 +233,13 @@
             Interlocked.CompareExchange<CancellationTokenSource?>(ref cts, null, localCTS);
         }
     }
+    
+   
+    public void goToCollectionPage()
+    {
+        string URL = $"/collections/{nft?.token}";
+        NavigationManager.NavigateTo(URL);
+    } 
 
 }
 

--- a/Lexplorer/Pages/NFTDetail.razor
+++ b/Lexplorer/Pages/NFTDetail.razor
@@ -237,7 +237,7 @@
    
     public void goToCollectionPage()
     {
-        string URL = $"/collections/{nft?.token}";
+        string URL = $"/nfts/collections/{nft?.token}";
         NavigationManager.NavigateTo(URL);
     } 
 

--- a/Lexplorer/Pages/NFTDetail.razor
+++ b/Lexplorer/Pages/NFTDetail.razor
@@ -84,14 +84,16 @@
                 <NFTContent nftMetadata="@nftMetadata" />
             </td>
         </tr>
-        <tr>
-            <td colspan="2">
-                @if(nft?.token != null)
-                {
-                    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="goToCollectionPage">View collection</MudButton>
-                }
-            </td>
-        </tr>
+        @if (nft?.token != null)
+        {
+            <tr>
+                <td colspan="2">
+             
+                        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="goToCollectionPage">View collection</MudButton>
+                    }
+                </td>
+            </tr>
+        }
     </tbody>
 </MudSimpleTable>
 

--- a/Shared/Services/LoopringGraphQLService.cs
+++ b/Shared/Services/LoopringGraphQLService.cs
@@ -1375,7 +1375,7 @@ namespace Lexplorer.Services
             }
         }
 
-        public async Task<IList<NonFungibleToken>?> GetCollectionNFTs(string tokenAddress, int skip = 0, int first = 12, string orderBy = "mintedAt", string orderDirection = "desc")
+        public async Task<IList<NonFungibleToken>?> GetCollectionNFTs(string tokenAddress, int skip = 0, int first = 12, string orderBy = "mintedAt", string orderDirection = "desc", CancellationToken cancellationToken = default)
         {
             var nonFungibleTokensQuery = @"
                 query nonFungibleTokens($where: NonFungibleToken_filter, $skip: Int, $first: Int, $orderDirection: OrderDirection, $orderBy: NonFungibleToken_orderBy) {

--- a/Shared/Services/LoopringGraphQLService.cs
+++ b/Shared/Services/LoopringGraphQLService.cs
@@ -1409,7 +1409,7 @@ namespace Lexplorer.Services
             });
             try
             {
-                var response = await _client.PostAsync(request);
+                var response = await _client.PostAsync(request, cancellationToken);
                 JObject jresponse = JObject.Parse(response.Content!);
                 JToken? token = jresponse["data"]!["nonFungibleTokens"];
                 return token!.ToObject<IList<NonFungibleToken>>();

--- a/Shared/Services/LoopringGraphQLService.cs
+++ b/Shared/Services/LoopringGraphQLService.cs
@@ -1399,7 +1399,7 @@ namespace Lexplorer.Services
                 {
                     where = new 
                     {
-                        token_in = new List<string> { tokenAddress }
+                        token_in = new List<string> { tokenAddress } //avoid invalid argument error with graph when using "token" string instead of "token_in"
                     },
                     skip = skip,
                     first = first,

--- a/Shared/Services/LoopringGraphQLService.cs
+++ b/Shared/Services/LoopringGraphQLService.cs
@@ -1375,6 +1375,52 @@ namespace Lexplorer.Services
             }
         }
 
+        public async Task<IList<NonFungibleToken>?> GetCollectionNFTs(string tokenAddress, int skip = 0, int first = 12, string orderBy = "mintedAt", string orderDirection = "desc")
+        {
+            var nonFungibleTokensQuery = @"
+                query nonFungibleTokens($where: NonFungibleToken_filter, $skip: Int, $first: Int, $orderDirection: OrderDirection, $orderBy: NonFungibleToken_orderBy) {
+                  nonFungibleTokens(where: $where, skip: $skip, first: $first, orderDirection: $orderDirection, orderBy: $orderBy) {
+                    ...NFTFragment
+                    __typename
+                  }
+                }
+            "
+              + GraphQLFragments.NFTFragment
+              + GraphQLFragments.AccountFragment
+              + GraphQLFragments.MintNFTFragmentWithoutNFT
+              + GraphQLFragments.TokenFragment;
+
+            var request = new RestRequest();
+            request.AddHeader("Content-Type", "application/json");
+            request.AddJsonBody(new
+            {
+                query = nonFungibleTokensQuery,
+                variables = new
+                {
+                    where = new 
+                    {
+                        token_in = new List<string> { tokenAddress }
+                    },
+                    skip = skip,
+                    first = first,
+                    orderBy = orderBy,
+                    orderDirection = orderDirection
+                }
+            });
+            try
+            {
+                var response = await _client.PostAsync(request);
+                JObject jresponse = JObject.Parse(response.Content!);
+                JToken? token = jresponse["data"]!["nonFungibleTokens"];
+                return token!.ToObject<IList<NonFungibleToken>>();
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine(ex.Message);
+                return null;
+            }
+        }
+
         public void Dispose()
         {
             _client?.Dispose();

--- a/xUnitTests/LoopringGraphTests/TestNFT.cs
+++ b/xUnitTests/LoopringGraphTests/TestNFT.cs
@@ -59,5 +59,13 @@ namespace xUnitTests.LoopringGraphTests
 
             Assert.Equal(nftCount, nfts!.Count);
         }
+
+        [Theory]
+        [InlineData("0x9af1b4f94657c79c4cff77c3c35a746353518724")]
+        public async void GetCollectionNFTs(string tokenAddress)
+        {
+            var nfts = await service.GetCollectionNFTs(tokenAddress);
+            Assert.NotEmpty(nfts);
+        }
     }
 }


### PR DESCRIPTION
fix #181 

- added a new method to the graphql service to query NFTs from a collection via the token address, in order of mint with recent mints first
- added a new unit test for the new graphql method mentioned previously
- added a new button to the nft details page which links to a new collection page
- the new collection page will utilise the new graphql method, along with our other services to get the nfts in a collection and display them. 
