### PR TITLE
Fix search errors

### DIFF
--- a/Shared/Services/LoopringGraphQLService.cs
+++ b/Shared/Services/LoopringGraphQLService.cs
@@ -1141,15 +1141,20 @@ namespace Lexplorer.Services
             ";
 
             string searchTermBytes = "";
-            //avoid query errors with search strings that cannot be converted to bytes
-            //extra searchTermBytes is only filled if it matches strict RegEx, starting with 0x (added if missing)
-            //and then any number of pairs "({2})+" of 0-9, a-f, A-F, end must be reached = $
             if (BigInteger.TryParse(searchTerm, out BigInteger nftBigIntID))
-                //strip of any leading zeros
-                searchTermBytes = "0x" + nftBigIntID.ToString("X").TrimStart('0').ToLower();
-
+            {
+                //strip of any leading zeros (#173) but also ensure even number of bytes (#183)
+                searchTermBytes = nftBigIntID.ToString("X").ToLower().Trim('0');
+                if (searchTermBytes.Length % 2 == 1)
+                    searchTermBytes = "0x0" + searchTermBytes;
+                else
+                    searchTermBytes = "0x" + searchTermBytes;
+            }
             else
             {
+                //avoid query errors with search strings that cannot be converted to bytes
+                //extra searchTermBytes is only filled if it matches strict RegEx, starting with 0x (added if missing)
+                //and then any number of pairs "({2})+" of 0-9, a-f, A-F, end must be reached = $
                 searchTermBytes = (searchTerm.StartsWith("0x", StringComparison.InvariantCultureIgnoreCase) ? searchTerm : "0x" + searchTerm).ToLower();
                 if (!Regex.Match(searchTermBytes, "0x([a-f0-9]{2})+$").Success)
                     searchTermBytes = "";

--- a/xUnitTests/LoopringGraphTests/TestSearch.cs
+++ b/xUnitTests/LoopringGraphTests/TestSearch.cs
@@ -41,6 +41,17 @@ namespace xUnitTests.LoopringGraphTests
         }
 
         [Theory]
+        [InlineData("81111")]
+        [InlineData("77900")]     
+        public async void SearchAccount(string accountID)
+        {
+            var searchResult = await service.Search(accountID);
+            Assert.NotEmpty(searchResult);
+            Assert.IsType<User>(searchResult![0]);
+            Assert.Equal(accountID, (searchResult![0] as User)!.id);
+        }
+
+        [Theory]
         [InlineData("8d785aabf440e369aae5e63bed8a0f1f560b4caf")]
         public async void SearchL1Address(string address)
         {


### PR DESCRIPTION
Fixes #183 

* graph returned error if BigInteger was parsed, but contained an
  odd number of bytes
* added new test case
* stripping leading zeros has to stay in there, as searching with
  2 leading zeros won't work (NFT test case failed)
* move old RegEx comment to where the code is now