### PR TITLE
Fix mixed up pagination icons in dark mode

### DIFF
--- a/Lexplorer/Pages/PairsDetail.razor
+++ b/Lexplorer/Pages/PairsDetail.razor
@@ -108,7 +108,7 @@
     private ApexChartOptions<PairDailyData> dailyVolumeChartOptions = new();
 
     private bool __isDarkMode = false;
-    [CascadingParameter]
+    [CascadingParameter(Name = "_isDarkMode")]
     protected bool _isDarkMode
     {
         get

--- a/Lexplorer/Shared/MainLayout.razor
+++ b/Lexplorer/Shared/MainLayout.razor
@@ -47,7 +47,7 @@
                     </RowTemplate>
                 </MudTable>
             }
-            <CascadingValue Value="@_isDarkMode">
+            <CascadingValue Name="_isDarkMode" Value="@_isDarkMode">
                 @Body
             </CascadingValue>
         </MudContainer>


### PR DESCRIPTION
Fix #176 by naming the CascadingValue for isDarkMode properly. 

Requires CascadingParameter property in PairsDetail to be named too.