### PR TITLE
Pools and pairs and pool token support

### DIFF
--- a/Lexplorer/Components/TransactionTableDetails.razor
+++ b/Lexplorer/Components/TransactionTableDetails.razor
@@ -1,4 +1,6 @@
-﻿@switch (TransactionData?.typeName)
+﻿@inject LoopringPoolTokenCacheService poolTokenCacheService;
+
+@switch (TransactionData?.typeName)
 {
     case "Deposit":
         <MudTd DataLabel="From Address"><L1AccountLink address="@deposit?.toAccount?.address" /></MudTd>
@@ -123,13 +125,13 @@
         <MudTd DataLabel="From Address">@LinkHelper.CreateUserLink(add?.account, ignoreUserIDForLink)</MudTd>
         <MudTd DataLabel="To Address">@LinkHelper.CreateUserLink(add?.pool, ignoreUserIDForLink)</MudTd>
         <MudTd></MudTd>
-        <MudTd DataLabel="Sold" Style="text-align:right">@TokenAmountConverter.ToString(add?.amount, add?.token?.decimals) @add?.token?.symbol</MudTd>
+        <MudTd DataLabel="Sold" Style="text-align:right">@TokenAmountConverter.ToString(add?.amount, addToken?.decimals) @addToken?.symbol</MudTd>
         <MudTd DataLabel="Fee" Style="text-align:right">@TokenAmountConverter.ToString(add?.fee, add?.feeToken?.decimals) @add?.feeToken?.symbol</MudTd>
         break;
     case "Remove":
         <MudTd DataLabel="From Address">@LinkHelper.CreateUserLink(remove?.pool, ignoreUserIDForLink)</MudTd>
         <MudTd DataLabel="To Address">@LinkHelper.CreateUserLink(remove?.account, ignoreUserIDForLink)</MudTd>
-        <MudTd DataLabel="Bought" Style="text-align:right">@TokenAmountConverter.ToString(remove?.amount, remove?.token?.decimals) @remove?.token?.symbol</MudTd>
+        <MudTd DataLabel="Bought" Style="text-align:right">@TokenAmountConverter.ToString(remove?.amount, removeToken?.decimals) @removeToken?.symbol</MudTd>
         <MudTd></MudTd>
         <MudTd DataLabel="Fee" Style="text-align:right">@TokenAmountConverter.ToString(remove?.fee, remove?.feeToken?.decimals) @remove?.feeToken?.symbol</MudTd>
         break;
@@ -158,7 +160,9 @@
     public Deposit? deposit { get { return TransactionData as Deposit; } }
     public Withdrawal? withdrawal { get { return TransactionData as Withdrawal; } }
     private Add? add { get { return TransactionData as Add; } }
+    private Token? addToken { get { return (add?.token == null) ? null : poolTokenCacheService.GetExistingPoolToken(add.token)?.token ?? add.token; } }
     private Remove? remove { get { return TransactionData as Remove; } }
+    private Token? removeToken { get { return (remove?.token == null) ? null : poolTokenCacheService.GetExistingPoolToken(remove.token)?.token ?? remove.token; } }
     private AmmUpdate? ammUpdate { get { return TransactionData as AmmUpdate; } }
     public MintNFT? mintNFT { get { return TransactionData as MintNFT; } }
     public TransferNFT? transferNFT { get { return TransactionData as TransferNFT; } }

--- a/Lexplorer/Pages/AccountDetails.razor
+++ b/Lexplorer/Pages/AccountDetails.razor
@@ -1,6 +1,7 @@
 ﻿@page "/account/{accountId}"
 @using System.Diagnostics
 @inject LoopringGraphQLService LoopringGraphQLService;
+@inject LoopringPoolTokenCacheService poolTokenCacheService;
 @inject EthereumService EthereumService;
 @inject NftMetadataService NftMetadataService;
 @inject NavigationManager NavigationManager;
@@ -37,6 +38,17 @@
                     <td>0x@((account as User)!.publicKey)</td>
                 </tr>
 
+            }
+            @if (poolToken != null)
+            {
+                <tr>
+                    <td>Pool token</td>
+                    <td>@(poolToken?.token?.name)</td>
+                </tr>
+                <tr>
+                    <td>Pair</td>
+                    <td>@LinkHelper.GetObjectLink(poolToken?.pair)</td>
+                </tr>
             }
         </tbody>
     </MudSimpleTable>
@@ -202,6 +214,7 @@
     public int nftPages = 0;
 
     private Account? account { get; set; }
+    private LoopringPoolToken? poolToken { get; set; }
     private IList<Transaction>? transactions { get; set; } = new List<Transaction>();
     private IList<AccountNFTSlot> accountNFTSlots { get; set; } = new List<AccountNFTSlot>();
     private Dictionary<string, NftMetadata> NFTdata { get; set; } = new Dictionary<string, NftMetadata>();
@@ -240,6 +253,22 @@
                     StateHasChanged();
                     account!.balances = await LoopringGraphQLService.GetAccountBalance(accountId, localCTS.Token);
                     localCTS.Token.ThrowIfCancellationRequested();
+                    if (account is Pool tempPool)
+                    {
+                        poolToken = await poolTokenCacheService.GetPoolToken(tempPool, localCTS.Token);
+                        localCTS.Token.ThrowIfCancellationRequested();
+                    }
+                    else
+                        poolToken = null;
+                    if (account.balances != null)
+                        foreach (var balance in account.balances)
+                        {
+                            if (balance.token == null)
+                                continue;
+                            LoopringPoolToken? poolToken = await poolTokenCacheService.GetPoolToken(balance.token);
+                            if (poolToken != null)
+                                balance.token = poolToken.token;
+                        }
                     balancesLoading = false;
                     StateHasChanged();
                 }

--- a/Lexplorer/Pages/AccountDetails.razor
+++ b/Lexplorer/Pages/AccountDetails.razor
@@ -74,7 +74,7 @@
                 </PagerContent>
             </MudTable>
         </MudTabPanel>
-        <MudTabPanel Text="NFTs">            
+        <MudTabPanel Text="NFTs">
             @if ((accountNFTSlots.Count < 1) && (gotoNFTPage == 1))
             {
                 <MudText class="pa-3">No NFTs</MudText>
@@ -83,17 +83,16 @@
             {
                 <MudGrid>
                     <MudItem xs="12" Class="d-flex justify-center">
-                        <MudPaper Width="100%" >
-                            
-                        <MudToolBar Class="justify-center">
-                            <MudPagination Size="Size.Small" ShowFirstButton="true" 
-                                BoundaryCount="1" 
-                                MiddleCount="1" 
-                                ShowLastButton="true" 
-                                Selected="@gotoNFTPage"
-                                Count="@nftPages"
-                                SelectedChanged="@((int page) => gotoNFTPage = page)"/>
-                        </MudToolBar>
+                        <MudPaper Width="100%">
+                            <MudToolBar Class="justify-center">
+                                <MudPagination Size="Size.Small" ShowFirstButton="true"
+                                               BoundaryCount="1"
+                                               MiddleCount="1"
+                                               ShowLastButton="true"
+                                               Selected="@gotoNFTPage"
+                                               Count="@nftPages"
+                                               SelectedChanged="@((int page) => gotoNFTPage = page)" />
+                            </MudToolBar>
                         </MudPaper>
                     </MudItem>
                     @foreach (var slot in accountNFTSlots)
@@ -115,20 +114,20 @@
                     }
                     <MudHidden Breakpoint="Breakpoint.MdAndDown" Invert="true">
                         <MudPaper Width="100%" Class="mx-4">
-	                    <MudToolBar Class="justify-center">
-                            <MudPagination Size="Size.Small" ShowFirstButton="true" 
-                                BoundaryCount="1" 
-                                MiddleCount="1" 
-                                ShowLastButton="true" 
-                                Selected="@gotoNFTPage"
-                                Count="@nftPages"
-                                SelectedChanged="@((int page) => gotoNFTPage = page)"/>
-                        </MudToolBar>
+                            <MudToolBar Class="justify-center">
+                                <MudPagination Size="Size.Small" ShowFirstButton="true"
+                                               BoundaryCount="1"
+                                               MiddleCount="1"
+                                               ShowLastButton="true"
+                                               Selected="@gotoNFTPage"
+                                               Count="@nftPages"
+                                               SelectedChanged="@((int page) => gotoNFTPage = page)" />
+                            </MudToolBar>
                         </MudPaper>
                     </MudHidden>
-                    <MudDivider DividerType="DividerType.Middle" Class="my-6"/>
+                    <MudDivider DividerType="DividerType.Middle" Class="my-6" />
                 </MudGrid>
-                
+
             }
         </MudTabPanel>
     </MudTabs>

--- a/Lexplorer/Pages/PairsDetail.razor
+++ b/Lexplorer/Pages/PairsDetail.razor
@@ -6,7 +6,8 @@
 @using ApexCharts;
 @inject IAppCache AppCache;
 @inject NavigationManager NavigationManager;
-@inject Lexplorer.Services.LoopringGraphQLService LoopringGraphQLService;
+@inject LoopringGraphQLService LoopringGraphQLService;
+@inject LoopringPoolTokenCacheService poolTokenCacheService;
 
 
 <PageTitle>The Lexplorer - pair @(pair?.token0?.symbol) / @(pair?.token1?.symbol) </PageTitle>
@@ -45,6 +46,14 @@
             <td>@TokenAmountConverter.ToStringWithExponent(pair?.tradedVolumeToken0Orderbook ?? 0, pair?.token0?.decimals ?? 0, 1) @pair?.token0?.symbol </td>
             <td>@TokenAmountConverter.ToStringWithExponent(pair?.tradedVolumeToken1Orderbook ?? 0, pair?.token1?.decimals ?? 0, 1) @pair?.token1?.symbol </td>
         </tr>
+        @if (poolToken != null)
+        {
+            <tr>
+                <td>Pool</td>
+                <td>@LinkHelper.GetObjectLink(poolToken.pool) </td>
+                <td>@poolToken.token?.name </td>
+            </tr>
+        }
     </tbody>
 </MudSimpleTable>
 
@@ -100,6 +109,7 @@
     public string pairId { get; set; } = "";
 
     private Pair? pair { get; set; } = new Pair();
+    private LoopringPoolToken? poolToken { get; set; }
     private IList<PairDailyData>? dailyData { get; set; } = null;
 
     private ApexChart<PairDailyData>? dailyPriceChart;
@@ -135,12 +145,15 @@
     {
         if (pair?.id != pairId)
         {
+            poolToken = null;
             dailyData = null;
             string pairCacheKey = $"pair-{pairId}";
             pair = await AppCache.GetOrAddAsyncNonNull(pairCacheKey,
                 async () => await LoopringGraphQLService.GetPair(pairId),
                 DateTimeOffset.UtcNow.AddHours(1));
             if (pair == null) return;
+            StateHasChanged();
+            poolToken = await poolTokenCacheService.GetPoolToken(pair);
             StateHasChanged();
             string dailyDataCacheKey = $"pair-{pairId}-dailyData";
             dailyData = await AppCache.GetOrAddAsyncNonNull(dailyDataCacheKey,

--- a/Lexplorer/Pages/PairsDetail.razor
+++ b/Lexplorer/Pages/PairsDetail.razor
@@ -185,7 +185,7 @@
                     //ideally implement something similar to TokenAmountConverter.ToStringWithExponent but in JS?
                     //as we're server side and the chart is JS, we can't call DotNet, i.e. our code
                     Formatter = @"function (value) {
-                        return Number(value).toLocaleString();}",
+                    return Number(value).toLocaleString();}",
                     MinWidth = 80
                 }
             }
@@ -210,7 +210,7 @@
                 {
                     //ideally implement something similar to TokenAmountConverter.ToStringWithExponent but in JS?
                     //as we're server side and the chart is JS, we can't call DotNet, i.e. our code
-                    Formatter = $"function (value) {{return Number(value).toLocaleString() + \" { pair?.token1?.symbol }\";}}",
+                    Formatter = $"function (value) {{return Number(value).toLocaleString() + \" {pair?.token1?.symbol}\";}}",
                     MinWidth = 80
                 }
             });

--- a/Lexplorer/Pages/TransactionDetail.razor
+++ b/Lexplorer/Pages/TransactionDetail.razor
@@ -1,6 +1,7 @@
 ﻿@page "/transactions/{transactionId}"
 @inject IAppCache AppCache;
 @inject LoopringGraphQLService LoopringGraphQLService;
+@inject LoopringPoolTokenCacheService poolTokenCacheService;
 
 <PageTitle>The Lexplorer - @(transaction?.typeName ?? "Transaction") #@transactionId </PageTitle>
 
@@ -178,7 +179,7 @@
             </tr>
             <tr>
                 <td>Amount</td>
-                <td colspan="2">@TokenAmountConverter.ToString(add.amount, add.token?.decimals) @add.token?.symbol</td>
+                <td colspan="2">@TokenAmountConverter.ToString(add.amount, addToken?.decimals) @addToken?.symbol</td>
             </tr>
             <tr>
                 <td>Fee</td>
@@ -199,7 +200,7 @@
             </tr>
             <tr>
                 <td>Amount</td>
-                <td colspan="2">@TokenAmountConverter.ToString(remove.amount, remove.token?.decimals) @remove.token?.symbol</td>
+                <td colspan="2">@TokenAmountConverter.ToString(remove.amount, removeToken?.decimals) @removeToken?.symbol</td>
             </tr>
             <tr>
                 <td>Fee</td>
@@ -369,7 +370,9 @@
     private Deposit? deposit { get { return transaction as Deposit; } }
     private Withdrawal? withdrawal { get { return transaction as Withdrawal; } }
     private Add? add { get { return transaction as Add; } }
+    private Token? addToken { get { return (add?.token == null) ? null : poolTokenCacheService.GetExistingPoolToken(add.token)?.token ?? add.token; } }
     private Remove? remove { get { return transaction as Remove; } }
+    private Token? removeToken { get { return (remove?.token == null) ? null : poolTokenCacheService.GetExistingPoolToken(remove.token)?.token ?? remove.token; } }
     private AmmUpdate? ammUpdate { get { return transaction as AmmUpdate; } }
     private MintNFT? mintNFT { get { return transaction as MintNFT; } }
     private TransferNFT? transferNFT { get { return transaction as TransferNFT; } }
@@ -385,7 +388,16 @@
         if (transaction?.id != transactionId)
         {
             transaction = await AppCache.GetOrAddAsyncNonNull(transactionCacheKey, async () => await LoopringGraphQLService.GetTransaction(transactionId));
-            StateHasChanged();
+
+            Pool? pool = null;
+            if (transaction is Remove tempRemove)
+                pool = tempRemove.pool;
+            if (transaction is AmmUpdate tempAmmUpdate)
+                pool = tempAmmUpdate.pool;
+            if (transaction is Add tempAdd)
+                pool = tempAdd.pool;
+            if (pool != null)
+                await poolTokenCacheService.GetPoolToken(pool);
         }
     }
 }

--- a/Lexplorer/Program.cs
+++ b/Lexplorer/Program.cs
@@ -16,6 +16,7 @@ builder.Services.AddSingleton<TransactionExportService>();
 builder.Services.AddSingleton<EthereumService>();
 builder.Services.AddSingleton<NftMetadataService>();
 builder.Services.AddSingleton<ILoopStatsService, LoopStatsService>();
+builder.Services.AddSingleton<LoopringPoolTokenCacheService>();
 builder.Services.AddLazyCache();
 
 //registration of CSV export formats, no automatic registration possible

--- a/Shared/Models/LoopringPoolToken.cs
+++ b/Shared/Models/LoopringPoolToken.cs
@@ -1,0 +1,11 @@
+﻿using System;
+namespace Lexplorer.Models
+{
+	public class LoopringPoolToken
+	{
+		public Token? token;
+		public Pool? pool;
+		public Pair? pair;
+	}
+}
+

--- a/Shared/Services/LoopringGraphQLService.cs
+++ b/Shared/Services/LoopringGraphQLService.cs
@@ -1500,7 +1500,7 @@ namespace Lexplorer.Services
                 else throw new ArgumentException($"GetSwapPairAndPool can only be called with swap, pool or pair, not {nameof(theObject)}");
 
                 request.AddStringBody(jObject.ToString(), ContentType.Json);
-                var response = await _client.PostAsync(request);
+                var response = await _client.PostAsync(request, cancellationToken);
                 JObject jresponse = JObject.Parse(response.Content!);
                 JToken result = jresponse["data"]!["swaps"]!;
                 return result.ToObject<IList<Swap>>()?.FirstOrDefault<Swap>();
@@ -1553,7 +1553,7 @@ namespace Lexplorer.Services
             request.AddStringBody(jObject.ToString(), ContentType.Json);
             try
             {
-                var response = await _client.PostAsync(request);
+                var response = await _client.PostAsync(request, cancellationToken);
                 JObject jresponse = JObject.Parse(response.Content!);
                 JToken result = jresponse["data"]!["removes"]!;
                 return result.ToObject<IList<Remove>>()?.FirstOrDefault<Remove>();

--- a/Shared/Services/LoopringPoolTokenCacheService.cs
+++ b/Shared/Services/LoopringPoolTokenCacheService.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Lexplorer.Models;
+
+namespace Lexplorer.Services
+{
+	public class LoopringPoolTokenCacheService
+	{
+        private readonly LoopringGraphQLService _loopringService;
+
+		private readonly Dictionary<string, LoopringPoolToken> poolTokensByTokenID = new ();
+        private readonly Dictionary<Tuple<string, string>, LoopringPoolToken> poolTokensByPairTokenIDs = new ();
+        private readonly Dictionary<string, LoopringPoolToken> poolTokensByPoolID = new();
+
+        public LoopringPoolTokenCacheService(LoopringGraphQLService loopringService)
+		{
+			_loopringService = loopringService;
+        }
+
+		private void AddCachedPoolToken(LoopringPoolToken token)
+        {
+            token.token!.name = $"LP-{token.pair!.token0!.symbol!.ToUpper()}-{token.pair!.token1!.symbol!.ToUpper()}";
+            token.token!.symbol = token.token.name;
+            token.token!.decimals = 8; //seems to be contant, see https://github.com/Loopring/protocols/blob/release_loopring_3.6.3/packages/loopring_v3/contracts/amm/PoolToken.sol
+            poolTokensByTokenID.Add(token.token!.id!, token);
+			poolTokensByPairTokenIDs.Add(new(token.pair!.token0!.id!, token.pair!.token1!.id!), token);
+			poolTokensByPoolID.Add(token.pool!.id!, token);
+        }
+
+        private LoopringPoolToken? GetCachedPoolToken(string token0ID, string token1ID)
+        {
+            LoopringPoolToken? token = null;
+            Tuple<string, string> pairTokenTuple = new(token0ID, token1ID);
+            if (!poolTokensByPairTokenIDs.TryGetValue(pairTokenTuple, out token))
+            {
+                //try other way around
+                pairTokenTuple = new(token1ID, token0ID);
+                poolTokensByPairTokenIDs.TryGetValue(pairTokenTuple, out token);
+            }
+            return token;
+        }
+
+        public async Task<LoopringPoolToken?> GetPoolToken(Pair pair, CancellationToken cancellationToken = default)
+        {
+            LoopringPoolToken? token = GetCachedPoolToken(pair.token0!.id!, pair.token1!.id!);
+            if (token != null)
+                return token;
+
+            return await AddPoolToken(pair, cancellationToken);
+        }
+
+        public async Task<LoopringPoolToken?> GetPoolToken(Pool pool, CancellationToken cancellationToken = default)
+        {
+            LoopringPoolToken? token = null;
+            if (poolTokensByPoolID.TryGetValue(pool.id!, out token))
+                return token;
+
+            return await AddPoolToken(pool, cancellationToken);
+        }
+
+        public async Task<LoopringPoolToken?> GetPoolToken(Swap swap, CancellationToken cancellationToken = default)
+        {
+            if (swap.pool != null)
+                return await GetPoolToken(swap.pool);
+            if (swap.pair != null)
+                return await GetPoolToken(swap.pair);
+            return await AddPoolToken(swap, cancellationToken);
+        }
+
+        public LoopringPoolToken? GetExistingPoolToken(Token token)
+        {
+            LoopringPoolToken? poolToken = null;
+            poolTokensByTokenID.TryGetValue(token.id!, out poolToken);
+            return poolToken;
+        }
+
+        public async Task<LoopringPoolToken?> GetPoolToken(Token token, CancellationToken cancellationToken = default)
+        {
+            LoopringPoolToken? poolToken = GetExistingPoolToken(token);
+            if (poolToken != null)
+                return poolToken;
+
+            //now how to do this??? -> get any Remove transaction with this tokenID
+            //but we have Removes with regular tokens as well, so only do this if token has no name
+            if (!string.IsNullOrEmpty(token.name))
+                return null;
+            Remove? remove = await _loopringService.GetAnyRemoveWithTokenID(token!.id!, cancellationToken);
+            if (remove?.pool == null)
+                return null;
+            return await AddPoolToken(remove.pool, cancellationToken);
+        }
+
+        private async Task<LoopringPoolToken?> AddPoolToken(Object theObject, CancellationToken cancellationToken = default)
+        {
+            LoopringPoolToken? token = null;
+            Swap? swap = await _loopringService.GetSwapPairAndPool(theObject, cancellationToken);
+            if ((swap != null) && (!poolTokensByPoolID.TryGetValue(swap.pool!.id!, out token)))
+            {
+                Token? poolToken = FindPoolToken(swap);
+                if (poolToken == null) return null;
+                token = new LoopringPoolToken();
+                token.token = poolToken;
+                token.pair = swap.pair;
+                token.pool = swap.pool;
+                AddCachedPoolToken(token);
+            }
+            return token!;
+        }
+
+        private Token? FindPoolToken(Swap swap)
+        {
+            if (swap.pool?.balances == null)
+                return null;
+            if ((swap.pair?.token0 == null) || (swap.pair?.token1 == null))
+                return null;
+
+            Token? poolToken = null;
+            bool token0Found = false;
+            bool token1Found = false;
+            foreach (var balance in swap.pool.balances)
+            {
+                if (balance.token?.id == swap.pair.token0.id)
+                    token0Found = true;
+                else if (balance.token?.id == swap.pair.token1.id)
+                    token1Found = true;
+                else if (string.IsNullOrEmpty(balance.token?.symbol))
+                    poolToken = balance.token!;
+            }
+            return ((token0Found) && (token1Found)) ? poolToken : null;
+        }
+
+    }
+}

--- a/Shared/Shared.projitems
+++ b/Shared/Shared.projitems
@@ -26,5 +26,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Services\TransactionExportDefaultCSVFormat.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Services\UniswapGraphQLService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Services\TransactionExportCointracking.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Services\LoopringPoolTokenCacheService.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Models\LoopringPoolToken.cs" />
   </ItemGroup>
 </Project>

--- a/xUnitTests/LoopringGraphTests/TestRemoveWithTokenID.cs
+++ b/xUnitTests/LoopringGraphTests/TestRemoveWithTokenID.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Lexplorer.Models;
+using Lexplorer.Services;
+using Xunit;
+
+namespace xUnitTests.LoopringGraphTests
+{
+    [Collection("LoopringGraphQL collection")]
+    public class TestRemoveWithTokenID
+	{
+        GraphQLTestsFixture fixture;
+        LoopringGraphQLService service;
+
+        public TestRemoveWithTokenID(GraphQLTestsFixture fixture)
+        {
+            this.fixture = fixture;
+            service = fixture!.LGS;
+        }
+
+        [Theory]
+        [InlineData("217")]
+        public async void GetRemoveWithTokenID(string tokenID)
+        {
+            var remove = await service.GetAnyRemoveWithTokenID(tokenID);
+            Assert.NotNull(remove);
+            Assert.NotNull(remove!.pool);
+            Assert.NotNull(remove!.token);
+        }
+	}
+}
+

--- a/xUnitTests/LoopringGraphTests/TestSwapPairAndPool.cs
+++ b/xUnitTests/LoopringGraphTests/TestSwapPairAndPool.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using Lexplorer.Models;
+using Lexplorer.Services;
+using Xunit;
+
+namespace xUnitTests.LoopringGraphTests
+{
+    [Collection("LoopringGraphQL collection")]
+    public class TestSwapPairAndPool
+	{
+        GraphQLTestsFixture fixture;
+        LoopringGraphQLService service;
+
+        public TestSwapPairAndPool(GraphQLTestsFixture fixture)
+        {
+            this.fixture = fixture;
+            service = fixture!.LGS;
+        }
+
+        [Theory]
+        [InlineData("99")]
+        public async void GetSwapWithPool(string poolID)
+        {
+            Pool pool = new();
+            pool.id = poolID;
+            var swap = await service.GetSwapPairAndPool(pool);
+            Assert.NotNull(swap);
+            Assert.NotNull(swap!.pool);
+            Assert.NotNull(swap.pool!.balances);
+            Assert.NotNull(swap.pair);
+            Assert.NotNull(swap.pair!.token0);
+            Assert.NotNull(swap.pair.token1);
+            Assert.Equal(poolID, swap!.pool!.id);
+        }
+
+        [Theory]
+        [InlineData("0-217")]
+        public async void GetSwapWithPair(string pairID)
+        {
+            Pair pair = new();
+            pair.id = pairID;
+            var swap = await service.GetSwapPairAndPool(pair);
+            Assert.NotNull(swap);
+            Assert.NotNull(swap!.pool);
+            Assert.NotNull(swap.pool!.balances);
+            Assert.NotNull(swap.pair);
+            Assert.NotNull(swap.pair!.token0);
+            Assert.NotNull(swap.pair.token1);
+            Assert.Equal(pairID, swap!.pair!.id);
+        }
+
+        [Theory]
+        [InlineData("10004-35")]
+        public async void GetSwapWithSwap(string swapID)
+        {
+            Swap querySwap = new();
+            querySwap.id = swapID;
+            var swap = await service.GetSwapPairAndPool(querySwap);
+            Assert.NotNull(swap);
+            Assert.NotNull(swap!.pool);
+            Assert.NotNull(swap.pool!.balances);
+            Assert.NotNull(swap.pair);
+            Assert.NotNull(swap.pair!.token0);
+            Assert.NotNull(swap.pair.token1);
+            Assert.Equal(swapID, swap.id);
+        }
+
+    }
+}


### PR DESCRIPTION
This tackles the long outstanding #63 without using the Loopring API but with some graphQL trickery:

<img width="1006" alt="image" src="https://user-images.githubusercontent.com/44807458/175306079-4725788d-a3b5-49a8-9c22-672dee74b93e.png">
<img width="898" alt="image" src="https://user-images.githubusercontent.com/44807458/175306188-b3e229bf-a963-4fb7-b11a-492d9978510c.png">

1. It builds its own never expiring cache (since the information cannot change really).
2. It has to make some assumptions (e.g. decimal places of pool tokens) but AFAICS these should all be okay.
3. Some of this - but not everything - would have been easier with the token list from the Loopring API (and of course with an improved graph none of this would have been necessary), but I am actually quite fine with the way this turned out.

@fudgebucket27 and @danielsolistensvik I'd love to hear your take on this!