### PR TITLE
New View JSON button on NFT details page

### DIFF
--- a/Lexplorer/Dialogs/NFTMetadataDialog.razor
+++ b/Lexplorer/Dialogs/NFTMetadataDialog.razor
@@ -1,0 +1,19 @@
+﻿
+<MudDialog>
+    <DialogContent>
+        <MudItem xs="12">
+            <MudTextField T="string" Variant="Variant.Outlined" Text="@JSON" Lines="20" ReadOnly="true" />
+        </MudItem>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@(() => MudDialog?.Close())">Close</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter]
+    MudDialogInstance? MudDialog { get; set; }
+
+    [Parameter]
+    public string JSON { get; set; } = "";
+}

--- a/Lexplorer/Pages/NFTDetail.razor
+++ b/Lexplorer/Pages/NFTDetail.razor
@@ -95,7 +95,7 @@
                     }
                     @if (nftMetadata?.JSONContent != null)
                     {
-                        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="showJSON" Class="mr-2">View JSON</MudButton>
+                        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="showJSON" Class="mr-2">View Metadata</MudButton>
                     }
                 </td>
             </tr>

--- a/Lexplorer/Pages/NFTDetail.razor
+++ b/Lexplorer/Pages/NFTDetail.razor
@@ -5,6 +5,7 @@
 @inject LoopringGraphQLService LoopringGraphQLService;
 @inject EthereumService EthereumService;
 @inject NftMetadataService NftMetadataService;
+@inject IDialogService DialogService;
 
 <PageTitle>The Lexplorer - NFT @nft?.nftID </PageTitle>
 
@@ -84,11 +85,18 @@
                 <NFTContent nftMetadata="@nftMetadata" />
             </td>
         </tr>
-        @if (nft?.token != null)
+        @if ((nft?.token ?? nftMetadata?.JSONContent) != null)
         {
             <tr>
                 <td colspan="2">
-                    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="goToCollectionPage">View collection</MudButton>
+                    @if (nft?.token != null)
+                    {
+                        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="goToCollectionPage" Class="mr-2">View collection</MudButton>
+                    }
+                    @if (nftMetadata?.JSONContent != null)
+                    {
+                        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="showJSON" Class="mr-2">View JSON</MudButton>
+                    }
                 </td>
             </tr>
         }
@@ -233,13 +241,23 @@
             Interlocked.CompareExchange<CancellationTokenSource?>(ref cts, null, localCTS);
         }
     }
-    
-   
+
+
     public void goToCollectionPage()
     {
         string URL = $"/nfts/collections/{nft?.token}";
         NavigationManager.NavigateTo(URL);
-    } 
+    }
+
+    public void showJSON()
+    {
+        var parameters = new DialogParameters();
+        parameters.Add("JSON", nftMetadata?.JSONContent);
+
+        var options = new DialogOptions() { CloseButton = true, MaxWidth = MaxWidth.Medium, FullWidth = true };
+
+        DialogService.Show<NFTMetadataDialog>("NFT metadata JSON", parameters, options);
+    }
 
 }
 

--- a/Shared/Models/NftMetadata.cs
+++ b/Shared/Models/NftMetadata.cs
@@ -14,6 +14,8 @@ namespace Lexplorer.Models
         public string? contentType { get; set; }
 
         public List<NftAttribute>? attributes { get; set; }
+
+        public string? JSONContent { get; set; }
     }
 
     public class NftAttribute

--- a/Shared/Services/NftMetadataService.cs
+++ b/Shared/Services/NftMetadataService.cs
@@ -8,6 +8,7 @@ using Lexplorer.Models;
 using System.Threading.Tasks;
 using System.Threading;
 using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json.Linq;
 
 namespace Lexplorer.Services
 {
@@ -60,7 +61,11 @@ namespace Lexplorer.Services
             {
                 request.Timeout = 10000; //we can't afford to wait forever here, 10s must be enough
                 var response = await _client.GetAsync(request, cancellationToken);
-                return JsonConvert.DeserializeObject<NftMetadata>(response.Content!);
+                var token = JToken.Parse(response.Content!);
+                var json = token.ToObject<NftMetadata>();
+                if ((token != null) && (json != null))
+                    json.JSONContent = token.ToString(Formatting.Indented);
+                return json;
             }
             catch (Exception e)
             {

--- a/Shared/Services/NftMetadataService.cs
+++ b/Shared/Services/NftMetadataService.cs
@@ -62,10 +62,10 @@ namespace Lexplorer.Services
                 request.Timeout = 10000; //we can't afford to wait forever here, 10s must be enough
                 var response = await _client.GetAsync(request, cancellationToken);
                 var token = JToken.Parse(response.Content!);
-                var json = token.ToObject<NftMetadata>();
-                if ((token != null) && (json != null))
-                    json.JSONContent = token.ToString(Formatting.Indented);
-                return json;
+                var metadata = token.ToObject<NftMetadata>();
+                if ((token != null) && (metadata != null))
+                    metadata.JSONContent = token.ToString(Formatting.Indented);
+                return metadata;
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Closes #190 

* added JSONContent to NftMetadata class
* MetadataService takes detour via JToken to beautify the .json and
  store it with the deserialized object
* NFT detail page shows additional button next to View collection
* button shows new dialog, just with a readonly text editor

<img width="1154" alt="image" src="https://user-images.githubusercontent.com/44807458/175561519-3a3395b5-e469-492b-9098-300d493f5a1c.png">
