### PR TITLE
Separated NFT grid

### DIFF
--- a/Lexplorer/Components/NFTGrid.razor
+++ b/Lexplorer/Components/NFTGrid.razor
@@ -1,0 +1,152 @@
+﻿@using System.Diagnostics;
+
+@inject EthereumService EthereumService;
+@inject NftMetadataService NftMetadataService;
+@inject IAppCache AppCache;
+
+@implements IDisposable
+
+<MudGrid>
+    <MudItem xs="12" Class="d-flex justify-center">
+        <MudPaper Width="100%">
+            <MudToolBar Class="justify-center">
+                <MudPagination Size="Size.Small" ShowFirstButton="true"
+                               BoundaryCount="1"
+                               MiddleCount="1"
+                               ShowLastButton="true"
+                               Selected="@PageNumber"
+                               Count="@PageCount"
+                               SelectedChanged="@((int page) => goToPage(page))" />
+            </MudToolBar>
+        </MudPaper>
+    </MudItem>
+    @if (NFTSlots != null && NFTSlots.Count > 0)
+    {
+        @foreach (var slot in NFTSlots!)
+        {
+            var metaData = GetMetadata(slot.nftID);
+            <MudItem xs="12" sm="4" md="4" lg="2">
+                <MudCard Style="height:100%;position:relative" Class="ma-1 border-solid">
+                    <MudCardMedia Image="@NftMetadataService.MakeIPFSLink(metaData?.image)" Style="object-fit:contain" />
+                    <MudCardContent>
+                        <MudText Typo="Typo.h6">@metaData?.name</MudText>
+                        <MudText Typo="Typo.body2">@metaData?.description</MudText>
+                    </MudCardContent>
+                    <MudCardActions>
+                        <MudButton Style="position:absolute;bottom:0;"
+                                   Variant="Variant.Text" Color="Color.Primary"
+                                   Link=@LinkHelper.GetObjectLinkAddress(slot)?.Item1>Go to NFT</MudButton>
+                    </MudCardActions>
+                </MudCard>
+            </MudItem>
+        }
+    }
+    else
+    {
+        <MudText class="pa-3">No NFTs</MudText>
+    }
+    <MudHidden Breakpoint="Breakpoint.MdAndDown" Invert="true">
+        <MudPaper Width="100%" Class="mx-4">
+            <MudToolBar Class="justify-center">
+                <MudPagination Size="Size.Small" ShowFirstButton="true"
+                               BoundaryCount="1"
+                               MiddleCount="1"
+                               ShowLastButton="true"
+                               Selected="@PageNumber"
+                               Count="@PageCount"
+                               SelectedChanged="@((int page) => goToPage(page))" />
+            </MudToolBar>
+        </MudPaper>
+    </MudHidden>
+    <MudDivider DividerType="DividerType.Middle" Class="my-6" />
+</MudGrid>
+
+@code {
+    [Parameter]
+    public int PageNumber { get; set; }
+
+    [Parameter]
+    public int PageCount { get; set; }
+
+    [Parameter]
+    public int PageSize { get; set; }
+
+    [Parameter]
+    public EventCallback<int> PageNumberChanged { get; set; }
+
+    public async Task goToPage(int page)
+    {
+        PageNumber = page;
+        await PageNumberChanged.InvokeAsync(PageNumber);
+    }
+
+    [Parameter]
+    public IList<NonFungibleToken>? NFTSlots { get; set; } = new List<NonFungibleToken>();
+    private Dictionary<string, NftMetadata> NFTdata { get; set; } = new Dictionary<string, NftMetadata>();
+    private CancellationTokenSource? cts = null;
+
+    protected override async Task OnParametersSetAsync()
+    {
+        //cancel any previous OnParametersSetAsync which might still be running
+        cts?.Cancel();
+
+        using (CancellationTokenSource localCTS = new CancellationTokenSource())
+        {
+            //give future calls a chance to cancel us; it is now safe to replace
+            //any previous value of cts, since we already cancelled it above
+            cts = localCTS;
+            try
+            {
+                NFTdata = new Dictionary<string, NftMetadata>();
+                if (NFTSlots != null)
+                {
+                    StateHasChanged();
+                    foreach (var slot in NFTSlots!)
+                    {
+                        string nftMetadataLinkCacheKey = $"nftMetadataLink-{slot.nftID}";
+                        string? nftMetadataLink = await AppCache.GetOrAddAsyncNonNull(nftMetadataLinkCacheKey,
+                            async () => await EthereumService.GetMetadataLink(slot.nftID, slot.token, slot.nftType),
+                            DateTimeOffset.UtcNow.AddHours(1));
+                        if (string.IsNullOrEmpty(nftMetadataLink)) continue;
+
+                        string nftMetadataCacheKey = $"nftMetadata-{nftMetadataLink}";
+                        var nftMetadata = await AppCache.GetOrAddAsyncNonNull(nftMetadataCacheKey,
+                            async () => await NftMetadataService.GetMetadata(nftMetadataLink, localCTS.Token),
+                            DateTimeOffset.UtcNow.AddHours(1));
+                        localCTS.Token.ThrowIfCancellationRequested();
+                        if (nftMetadata == null) continue;
+
+                        NFTdata.Add(slot.nftID!, nftMetadata);
+                        StateHasChanged();
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (Exception e)
+            {
+                Trace.WriteLine(e.StackTrace + "\n" + e.Message);
+            }
+            //now for cleanup, we must clear cts, but only if it is still our localCTS, which we're about to dispose
+            //otherwise a new call has already replaced cts with it's own localCTS
+            Interlocked.CompareExchange<CancellationTokenSource?>(ref cts, null, localCTS);
+        }
+    }
+
+    public void Dispose()
+    {
+        cts?.Cancel();
+    }
+
+    private NftMetadata? GetMetadata(string? nftID)
+    {
+        NftMetadata? data = null;
+        if (nftID != null)
+        {
+            NFTdata.TryGetValue(nftID, out data);
+        }
+        return data;
+    }
+}
+

--- a/Lexplorer/Components/NFTGrid.razor
+++ b/Lexplorer/Components/NFTGrid.razor
@@ -24,18 +24,22 @@
     {
         @foreach (var slot in NFTSlots!)
         {
-            var metaData = GetMetadata(slot.nftID);
+            var metaData = GetMetadata(slot.nft?.nftID);
             <MudItem xs="12" sm="4" md="4" lg="2">
                 <MudCard Style="height:100%;position:relative" Class="ma-1 border-solid">
                     <MudCardMedia Image="@NftMetadataService.MakeIPFSLink(metaData?.image)" Style="object-fit:contain" />
                     <MudCardContent>
                         <MudText Typo="Typo.h6">@metaData?.name</MudText>
+                        @if (slot.balance > 0)
+                        { 
+                            <MudChip Label="true" Color="Color.Primary" Class="ml-0">x @slot.balance.ToString("#,##0")</MudChip>
+                        }
                         <MudText Typo="Typo.body2">@metaData?.description</MudText>
                     </MudCardContent>
                     <MudCardActions>
                         <MudButton Style="position:absolute;bottom:0;"
                                    Variant="Variant.Text" Color="Color.Primary"
-                                   Link=@LinkHelper.GetObjectLinkAddress(slot)?.Item1>Go to NFT</MudButton>
+                                   Link=@LinkHelper.GetObjectLinkAddress(slot.nft)?.Item1>Go to NFT</MudButton>
                     </MudCardActions>
                 </MudCard>
             </MudItem>
@@ -81,7 +85,7 @@
     }
 
     [Parameter]
-    public IList<NonFungibleToken>? NFTSlots { get; set; } = new List<NonFungibleToken>();
+    public IList<AccountNFTSlot>? NFTSlots { get; set; } = new List<AccountNFTSlot>();
     private Dictionary<string, NftMetadata> NFTdata { get; set; } = new Dictionary<string, NftMetadata>();
     private CancellationTokenSource? cts = null;
 
@@ -103,9 +107,10 @@
                     StateHasChanged();
                     foreach (var slot in NFTSlots!)
                     {
-                        string nftMetadataLinkCacheKey = $"nftMetadataLink-{slot.nftID}";
+                        if (slot.nft == null) continue;
+                        string nftMetadataLinkCacheKey = $"nftMetadataLink-{slot.nft.nftID}";
                         string? nftMetadataLink = await AppCache.GetOrAddAsyncNonNull(nftMetadataLinkCacheKey,
-                            async () => await EthereumService.GetMetadataLink(slot.nftID, slot.token, slot.nftType),
+                            async () => await EthereumService.GetMetadataLink(slot.nft.nftID, slot.nft.token, slot.nft.nftType),
                             DateTimeOffset.UtcNow.AddHours(1));
                         if (string.IsNullOrEmpty(nftMetadataLink)) continue;
 
@@ -116,7 +121,7 @@
                         localCTS.Token.ThrowIfCancellationRequested();
                         if (nftMetadata == null) continue;
 
-                        NFTdata.Add(slot.nftID!, nftMetadata);
+                        NFTdata.Add(slot.nft.nftID!, nftMetadata);
                         StateHasChanged();
                     }
                 }

--- a/Lexplorer/Pages/AccountDetails.razor
+++ b/Lexplorer/Pages/AccountDetails.razor
@@ -230,17 +230,17 @@
                 localCTS.Token.ThrowIfCancellationRequested();
                 nftPages = (int)Math.Ceiling(decimal.Divide(totalNfts, nftPageSize));
 
-                string transactionCacheKey = $"account{accountId}-transactions-page{pageNumber}";
-                transactions = await AppCache.GetOrAddAsyncNonNull(transactionCacheKey,
-                    async () => await LoopringGraphQLService.GetAccountTransactions((gotoPage - 1) * pageSize, pageSize, accountId, cancellationToken: localCTS.Token),
-                    DateTimeOffset.UtcNow.AddMinutes(10));
-                localCTS.Token.ThrowIfCancellationRequested();
-                StateHasChanged();
-
                 string nftCacheKey = $"account{accountId}-nftSlots-page{nftPageNumber}";
                 accountNFTSlots = await AppCache.GetOrAddAsyncNonNull(nftCacheKey,
                     async () => await LoopringGraphQLService.GetAccountNFTs((gotoNFTPage - 1) * nftPageSize, nftPageSize, accountId, localCTS.Token),
                     DateTimeOffset.UtcNow.AddMinutes(10)) ?? new List<AccountNFTSlot>();
+                localCTS.Token.ThrowIfCancellationRequested();
+                StateHasChanged();
+
+                string transactionCacheKey = $"account{accountId}-transactions-page{pageNumber}";
+                transactions = await AppCache.GetOrAddAsyncNonNull(transactionCacheKey,
+                    async () => await LoopringGraphQLService.GetAccountTransactions((gotoPage - 1) * pageSize, pageSize, accountId, cancellationToken: localCTS.Token),
+                    DateTimeOffset.UtcNow.AddMinutes(10));
                 localCTS.Token.ThrowIfCancellationRequested();
 
                 isLoading = false;

--- a/Lexplorer/Pages/AccountDetails.razor
+++ b/Lexplorer/Pages/AccountDetails.razor
@@ -75,60 +75,7 @@
             </MudTable>
         </MudTabPanel>
         <MudTabPanel Text="NFTs">
-            @if ((accountNFTSlots.Count < 1) && (gotoNFTPage == 1))
-            {
-                <MudText class="pa-3">No NFTs</MudText>
-            }
-            else
-            {
-                <MudGrid>
-                    <MudItem xs="12" Class="d-flex justify-center">
-                        <MudPaper Width="100%">
-                            <MudToolBar Class="justify-center">
-                                <MudPagination Size="Size.Small" ShowFirstButton="true"
-                                               BoundaryCount="1"
-                                               MiddleCount="1"
-                                               ShowLastButton="true"
-                                               Selected="@gotoNFTPage"
-                                               Count="@nftPages"
-                                               SelectedChanged="@((int page) => gotoNFTPage = page)" />
-                            </MudToolBar>
-                        </MudPaper>
-                    </MudItem>
-                    @foreach (var slot in accountNFTSlots)
-                    {
-                        var metaData = GetMetadata(slot.nft?.id);
-                        <MudItem xs="12" sm="4" md="4" lg="2">
-                            <MudCard Style="height:100%;position:relative" Class="ma-1 border-solid">
-                                <MudCardMedia Image="@NftMetadataService.MakeIPFSLink(metaData?.image)" Style="object-fit:contain" />
-                                <MudCardContent>
-                                    <MudText Typo="Typo.h6">@metaData?.name</MudText>
-                                    <MudChip Label="true" Color="Color.Primary" Class="ml-0">x @slot.balance.ToString("#,##0")</MudChip>
-                                    <MudText Typo="Typo.body2">@metaData?.description</MudText>
-                                </MudCardContent>
-                                <MudCardActions>
-                                    <MudButton Style="position:absolute;bottom:0;" Variant="Variant.Text" Color="Color.Primary" Link=@LinkHelper.GetObjectLinkAddress(slot.nft)?.Item1>Go to NFT</MudButton>
-                                </MudCardActions>
-                            </MudCard>
-                        </MudItem>
-                    }
-                    <MudHidden Breakpoint="Breakpoint.MdAndDown" Invert="true">
-                        <MudPaper Width="100%" Class="mx-4">
-                            <MudToolBar Class="justify-center">
-                                <MudPagination Size="Size.Small" ShowFirstButton="true"
-                                               BoundaryCount="1"
-                                               MiddleCount="1"
-                                               ShowLastButton="true"
-                                               Selected="@gotoNFTPage"
-                                               Count="@nftPages"
-                                               SelectedChanged="@((int page) => gotoNFTPage = page)" />
-                            </MudToolBar>
-                        </MudPaper>
-                    </MudHidden>
-                    <MudDivider DividerType="DividerType.Middle" Class="my-6" />
-                </MudGrid>
-
-            }
+            <NFTGrid @bind-PageNumber="@gotoNFTPage" NFTSlots="@accountNFTSlots" PageSize="@nftPageSize" PageCount="@nftPages" />
         </MudTabPanel>
     </MudTabs>
 
@@ -210,13 +157,12 @@
     public readonly int pageSize = 25;
     public readonly int nftPageSize = 12; //6 per row
     public int totalNfts = 0;
-    public int nftPages = 0;
+    public int nftPages = 1;
 
     private Account? account { get; set; }
     private LoopringPoolToken? poolToken { get; set; }
     private IList<Transaction>? transactions { get; set; } = new List<Transaction>();
     private IList<AccountNFTSlot> accountNFTSlots { get; set; } = new List<AccountNFTSlot>();
-    private Dictionary<string, NftMetadata> NFTdata { get; set; } = new Dictionary<string, NftMetadata>();
     private CancellationTokenSource? cts;
 
     protected override async Task OnParametersSetAsync()
@@ -297,33 +243,7 @@
                     DateTimeOffset.UtcNow.AddMinutes(10)) ?? new List<AccountNFTSlot>();
                 localCTS.Token.ThrowIfCancellationRequested();
 
-                Dictionary<string, NftMetadata> localNFTdata = new Dictionary<string, NftMetadata>();
-                NFTdata = localNFTdata;
-
-                if (accountNFTSlots != null)
-                {
-                    StateHasChanged();
-                    foreach (var slot in accountNFTSlots!)
-                    {
-                        string nftMetadataLinkCacheKey = $"nftMetadataLink-{slot.nft!.nftID}";
-                        string? nftMetadataLink = await AppCache.GetOrAddAsyncNonNull(nftMetadataLinkCacheKey,
-                            async () => await EthereumService.GetMetadataLink(slot.nft?.nftID, slot.nft?.token, slot.nft?.nftType),
-                            DateTimeOffset.UtcNow.AddHours(1));
-                        if (string.IsNullOrEmpty(nftMetadataLink)) continue;
-
-                        string nftMetadataCacheKey = $"nftMetadata-{nftMetadataLink}";
-                        var nftMetadata = await AppCache.GetOrAddAsyncNonNull(nftMetadataCacheKey,
-                            async () => await NftMetadataService.GetMetadata(nftMetadataLink, localCTS.Token),
-                            DateTimeOffset.UtcNow.AddHours(1));
-                        localCTS.Token.ThrowIfCancellationRequested();
-                        if (nftMetadata == null) continue;
-
-                        localNFTdata.Add(slot.nft!.id!, nftMetadata);
-                        StateHasChanged();
-                    }
-                }
                 isLoading = false;
-                StateHasChanged();
             }
             catch (OperationCanceledException)
             {
@@ -336,16 +256,6 @@
             //otherwise a new call has already replaced cts with it's own localCTS
             Interlocked.CompareExchange<CancellationTokenSource?>(ref cts, null, localCTS);
         }
-    }
-
-    private NftMetadata? GetMetadata(string? nftID)
-    {
-        NftMetadata? data = null;
-        if (nftID != null)
-        {
-            NFTdata.TryGetValue(nftID, out data);
-        }
-        return data;
     }
 
     private void ShowCSVOptions()

--- a/Lexplorer/Pages/NFTCollection.razor
+++ b/Lexplorer/Pages/NFTCollection.razor
@@ -41,7 +41,7 @@
     public int maxPageCount { get; set; } = 1;
 
     private CancellationTokenSource? cts;
-    private IList<NonFungibleToken>? collectionNFTSlots { get; set; } = new List<NonFungibleToken>();
+    private IList<AccountNFTSlot>? collectionNFTSlots { get; set; } = new List<AccountNFTSlot>();
     protected override async Task OnParametersSetAsync()
     {
         //quickly and early ensure that maxPageCount never get's smaller than the page we're on
@@ -60,11 +60,16 @@
                 if (string.IsNullOrEmpty(tokenAddress)) return;
 
                 string collectionNftKey = $"collection-{tokenAddress}-page-{goToPage}";
-                collectionNFTSlots = await AppCache.GetOrAddAsyncNonNull(collectionNftKey,
+                var collectionNFTs = await AppCache.GetOrAddAsyncNonNull(collectionNftKey,
                     async () => await LoopringGraphQLService.GetCollectionNFTs(tokenAddress, (goToPage - 1) * pageSize, cancellationToken: localCTS.Token),
                     DateTimeOffset.UtcNow.AddMinutes(10));
                 localCTS.Token.ThrowIfCancellationRequested();
-                maxPageCount = Math.Max(maxPageCount, goToPage + (collectionNFTSlots?.Count < pageSize ? 0 : 1));
+                maxPageCount = Math.Max(maxPageCount, goToPage + (collectionNFTs?.Count < pageSize ? 0 : 1));
+
+                //transform list of nfts to list of accountsSlots with everything else empty/null
+                collectionNFTSlots = collectionNFTs?.
+                    Select(NFT => new AccountNFTSlot() { nft = NFT }).ToList() ??
+                    new List<AccountNFTSlot>();
             }
             catch (OperationCanceledException)
             {

--- a/Lexplorer/Pages/NFTCollection.razor
+++ b/Lexplorer/Pages/NFTCollection.razor
@@ -11,58 +11,7 @@
 <MudContainer Fixed="true" Class="px-0 extra-extra-extra-large">
     <MudText Typo="Typo.h6">NFT Contract Address <L1AccountLink address="@tokenAddress" shortenAddress="false" /></MudText>
     <br />
-    <MudGrid>
-        <MudItem xs="12" Class="d-flex justify-center">
-            <MudPaper Width="100%" >
-            <MudToolBar Class="justify-center">
-                <MudPagination Size="Size.Small" ShowFirstButton="true" 
-                                BoundaryCount="1" 
-                                MiddleCount="1" 
-                                ShowLastButton="true" 
-                                Selected="@goToPage"
-                                Count="@calculatePageCount"
-                                SelectedChanged="@((int page) => goToPage = page)"/>
-                        </MudToolBar>
-                        </MudPaper>
-                    </MudItem>
-        @if (collectionNFTSlots != null && collectionNFTSlots.Count > 0)
-        {
-            @foreach (var slot in collectionNFTSlots!)
-            {
-                var metaData = GetMetadata(slot.nftID);
-                <MudItem xs="12" sm="4" md="4" lg="2">
-                    <MudCard Style="height:100%;position:relative" Class="ma-1 border-solid">
-                           <MudCardMedia Image="@NftMetadataService.MakeIPFSLink(metaData?.image)" Style="object-fit:contain" />
-                           <MudCardContent>
-                               <MudText Typo="Typo.h6">@metaData?.name</MudText>
-                               <MudText Typo="Typo.body2">@metaData?.description</MudText>
-                           </MudCardContent>
-                           <MudCardActions>
-                               <MudButton Style="position:absolute;bottom:0;" Variant="Variant.Text" Color="Color.Primary" Link=@LinkHelper.GetObjectLinkAddress(slot)?.Item1>Go to NFT</MudButton>
-                           </MudCardActions>
-                    </MudCard>
-                </MudItem>
-            }
-        }
-        else
-        {
-            <MudText class="pa-3">No NFTs</MudText>
-        }
-        <MudHidden Breakpoint="Breakpoint.MdAndDown" Invert="true">
-            <MudPaper Width="100%" Class="mx-4">
-                <MudToolBar Class="justify-center">
-                    <MudPagination Size="Size.Small" ShowFirstButton="true" 
-                    BoundaryCount="1" 
-                    MiddleCount="1" 
-                    ShowLastButton="true" 
-                    Selected="@goToPage"
-                    Count="@calculatePageCount"
-                    SelectedChanged="@((int page) => goToPage = page)"/>
-                 </MudToolBar>
-           </MudPaper>
-       </MudHidden>
-       <MudDivider DividerType="DividerType.Middle" Class="my-6"/>
-    </MudGrid>
+    <NFTGrid @bind-PageNumber="@goToPage" NFTSlots="@collectionNFTSlots" PageSize="@pageSize" PageCount="@maxPageCount" />
 </MudContainer>
 
 @code {
@@ -81,26 +30,23 @@
         }
         set
         {
-            pageNumber = value.ToString(); //set immediately for MudPagination to not switch forth and back
-            string URL = $"/nfts/collections/{tokenAddress}?pageNumber={value}";
+            pageNumber = value.ToString(); //set immediately for NFTGrid to not switch forth and back
+            var URL = NavigationManager.GetUriWithQueryParameter(nameof(pageNumber), value);
             NavigationManager.NavigateTo(URL);
         }
     }
 
-    public int calculatePageCount
-    {
-        get
-        {
-            return goToPage + ((collectionNFTSlots?.Count < pageSize) ? 0 : 1);
-        }
-    }
-
     public readonly int pageSize = 12; //6 per row
+
+    public int maxPageCount { get; set; } = 1;
+
     private CancellationTokenSource? cts;
     private IList<NonFungibleToken>? collectionNFTSlots { get; set; } = new List<NonFungibleToken>();
-    private Dictionary<string, NftMetadata> NFTdata { get; set; } = new Dictionary<string, NftMetadata>();
     protected override async Task OnParametersSetAsync()
     {
+        //quickly and early ensure that maxPageCount never get's smaller than the page we're on
+        maxPageCount = Math.Max(maxPageCount, goToPage);
+
         //cancel any previous OnParametersSetAsync which might still be running
         cts?.Cancel();
 
@@ -118,31 +64,7 @@
                     async () => await LoopringGraphQLService.GetCollectionNFTs(tokenAddress, (goToPage - 1) * pageSize, cancellationToken: localCTS.Token),
                     DateTimeOffset.UtcNow.AddMinutes(10));
                 localCTS.Token.ThrowIfCancellationRequested();
-                Dictionary<string, NftMetadata> localNFTdata = new Dictionary<string, NftMetadata>();
-                NFTdata = localNFTdata;
-                if (collectionNFTSlots != null)
-                {
-                    StateHasChanged();
-                    foreach (var slot in collectionNFTSlots!)
-                    {
-                        string nftMetadataLinkCacheKey = $"nftMetadataLink-{slot.nftID}";
-                        string? nftMetadataLink = await AppCache.GetOrAddAsyncNonNull(nftMetadataLinkCacheKey,
-                            async () => await EthereumService.GetMetadataLink(slot.nftID, tokenAddress, slot.nftType),
-                            DateTimeOffset.UtcNow.AddHours(1));
-                        if (string.IsNullOrEmpty(nftMetadataLink)) continue;
-
-                        string nftMetadataCacheKey = $"nftMetadata-{nftMetadataLink}";
-                        var nftMetadata = await AppCache.GetOrAddAsyncNonNull(nftMetadataCacheKey,
-                            async () => await NftMetadataService.GetMetadata(nftMetadataLink, localCTS.Token),
-                            DateTimeOffset.UtcNow.AddHours(1));
-                        localCTS.Token.ThrowIfCancellationRequested();
-                        if (nftMetadata == null) continue;
-
-                        localNFTdata.Add(slot.nftID!, nftMetadata);
-                        StateHasChanged();
-                    }
-                }
-                StateHasChanged();
+                maxPageCount = Math.Max(maxPageCount, goToPage + (collectionNFTSlots?.Count < pageSize ? 0 : 1));
             }
             catch (OperationCanceledException)
             {
@@ -155,16 +77,6 @@
             //otherwise a new call has already replaced cts with it's own localCTS
             Interlocked.CompareExchange<CancellationTokenSource?>(ref cts, null, localCTS);
         }
-    }
-
-    private NftMetadata? GetMetadata(string? nftID)
-    {
-        NftMetadata? data = null;
-        if (nftID != null)
-        {
-            NFTdata.TryGetValue(nftID, out data);
-        }
-        return data;
     }
 
  }


### PR DESCRIPTION
Closes #193 

Wow, that has been quite a ride, lots of new things learnt, but I think I got everything! Cancellation etc. work, directly changing page numbers via the URL etc. all still seem to work just fine!

No visual changes AFAICS.

The grid needs to have a list of `AccountNFTSlot`, not `NonFungibleToken`, for it to display the balance - when viewing on AccountDetails. For the collection view, a LINQ transformation of the list is therefore necessary, but I don't think that'll hurt.

Please give it a thorough test drive on dev.

Now that this is separated out, we can tackle #180 