### PR TITLE
Speed up transactions query

### DIFF
--- a/Shared/Helpers/GraphQLTransactionListFragments.cs
+++ b/Shared/Helpers/GraphQLTransactionListFragments.cs
@@ -1,0 +1,301 @@
+﻿using System;
+
+namespace Lexplorer.Helpers
+{
+	public static class GraphQLTransactionListFragments
+	{
+        //this class collects more compact and less nested fragments used when
+        //querying lists of transactions
+
+        public static string Account = @"
+            fragment AccountFragment on Account {
+                id
+                address
+                __typename
+            }";
+
+        public static string Token = @"
+            fragment TokenFragment on Token {
+                id
+                name
+                symbol
+                decimals
+              }";
+
+        public static string Swap = @"
+        fragment SwapFragment on Swap {
+            id
+            account {
+              ...AccountFragment
+            }
+            pool {
+              ...AccountFragment
+            }
+            tokenA {
+              ...TokenFragment
+            }
+            tokenB {
+              ...TokenFragment
+            }
+            fillSA
+            fillSB
+            fillBA
+            fillBB
+            feeA
+            feeB
+            __typename
+          }";
+
+        public static string Add = @"
+        fragment AddFragment on Add {
+            id
+            account {
+              ...AccountFragment
+            }
+            pool {
+              ...AccountFragment
+            }
+            token {
+              ...TokenFragment
+            }
+            feeToken {
+              ...TokenFragment
+            }
+            amount
+            fee
+            __typename
+          }";
+
+        public static string Remove = @"
+         fragment RemoveFragment on Remove {
+            id
+            account {
+              ...AccountFragment
+            }
+            pool {
+              ...AccountFragment
+            }
+            token {
+              ...TokenFragment
+            }
+            feeToken {
+              ...TokenFragment
+            }
+            amount
+            fee
+            __typename
+          }";
+
+        public static string OrderBookTrade = @"
+          fragment OrderbookTradeFragment on OrderbookTrade {
+            id
+            accountA {
+              ...AccountFragment
+            }
+            accountB {
+              ...AccountFragment
+            }
+            tokenA {
+              ...TokenFragment
+            }
+            tokenB {
+              ...TokenFragment
+            }
+            fillSA
+            fillSB
+            fillBA
+            fillBB
+            fillAmountBorSA
+            fillAmountBorSB
+            feeA
+            feeB
+            __typename
+          }";
+
+        public static string Deposit = @"
+          fragment DepositFragment on Deposit {
+            id
+            toAccount {
+              ...AccountFragment
+            }
+            token {
+              ...TokenFragment
+            }
+            amount
+            __typename
+          }";
+
+        public static string Withdrawal = @"
+          fragment WithdrawalFragment on Withdrawal {
+            id
+            fromAccount {
+              ...AccountFragment
+            }
+            token {
+              ...TokenFragment
+            }
+            feeToken {
+              ...TokenFragment
+            }
+            amount
+            fee
+            __typename
+          }";
+
+        public static string Transfer = @"
+         fragment TransferFragment on Transfer {
+            id
+            fromAccount {
+              ...AccountFragment
+            }
+            toAccount {
+              ...AccountFragment
+            }
+            token {
+              ...TokenFragment
+            }
+            feeToken {
+              ...TokenFragment
+            }
+            amount
+            fee
+            __typename
+          }";
+
+        public static string AccountUpdate = @"
+          fragment AccountUpdateFragment on AccountUpdate {
+            id
+            user {
+              ...AccountFragment
+            }
+            feeToken {
+              ...TokenFragment
+            }
+            fee
+            __typename
+          }";
+
+        public static string AmmUpdate = @"
+          fragment AmmUpdateFragment on AmmUpdate {
+            id
+            pool {
+              ...AccountFragment
+            }
+            balance
+            __typename
+          }";
+
+        public static string SignatureVerification = @"
+          fragment SignatureVerificationFragment on SignatureVerification {
+            id
+            account {
+              ...AccountFragment
+            }
+            __typename
+          }";
+
+        public static string TradeNFT = @"
+          fragment TradeNFTFragment on TradeNFT {
+            id
+            accountSeller {
+              ...AccountFragment
+            }
+            accountBuyer {
+              ...AccountFragment
+            }
+            token {
+              ...TokenFragment
+            }
+            realizedNFTPrice
+            feeBuyer
+            feeSeller
+            fillSA
+            fillBA
+            fillSB
+            fillBB
+            tokenIDAS
+            __typename
+          }";
+
+        public static string SwapNFT = @"
+         fragment SwapNFTFragment on SwapNFT {
+            id
+            accountA {
+              ...AccountFragment
+            }
+            accountB {
+              ...AccountFragment
+            }
+            __typename
+          }";
+
+        public static string WithdrawalNFT = @"
+          fragment WithdrawalNFTFragment on WithdrawalNFT {
+            id
+            fromAccount {
+              ...AccountFragment
+            }
+            fee
+            feeToken {
+              ...TokenFragment
+            }
+            amount
+            __typename
+          }";
+
+        public static string TransferNFT = @"
+          fragment TransferNFTFragment on TransferNFT {
+            id
+            fromAccount {
+              ...AccountFragment
+            }
+            toAccount {
+              ...AccountFragment
+            }
+            feeToken {
+              ...TokenFragment
+            }
+            fee
+            amount
+            __typename
+          }";
+
+        public static string MintNFT = @"
+          fragment MintNFTFragment on MintNFT {
+            id
+            minter {
+              ...AccountFragment
+            }
+            receiver {
+              ...AccountFragment
+            }
+            fee
+            feeToken {
+              ...TokenFragment
+            }
+            amount
+            __typename
+          }";
+
+        public static string AllFragments =
+            Account
+              + Token
+              + Add
+              + Remove
+              + Swap
+              + OrderBookTrade
+              + Deposit
+              + Withdrawal
+              + Transfer
+              + AccountUpdate
+              + AmmUpdate
+              + SignatureVerification
+              + TradeNFT
+              + SwapNFT
+              + WithdrawalNFT
+              + TransferNFT
+              + MintNFT;
+
+    }
+}
+

--- a/Shared/Services/LoopringGraphQLService.cs
+++ b/Shared/Services/LoopringGraphQLService.cs
@@ -342,28 +342,8 @@ namespace Lexplorer.Services
                   id
                   internalID
                   block {
-                    id
-                    blockHash
                     timestamp
-                    transactionCount
-                    depositCount
-                    withdrawalCount
-                    transferCount
-                    addCount
-                    removeCount
-                    orderbookTradeCount
-                    swapCount
-                    accountUpdateCount
-                    ammUpdateCount
-                    signatureVerificationCount
-                    tradeNFTCount
-                    swapNFTCount
-                    withdrawalNFTCount
-                    transferNFTCount
-                    nftMintCount
-                    nftDataCount
                   }
-                  data
                   ...AddFragment
                   ...RemoveFragment
                   ...SwapFragment
@@ -379,30 +359,9 @@ namespace Lexplorer.Services
                   ...WithdrawalNFTFragment
                   ...TransferNFTFragment
                   ...MintNFTFragment
-                  ...DataNFTFragment
                 }
               }"
-              + GraphQLFragments.AccountFragment
-              + GraphQLFragments.TokenFragment
-              + GraphQLFragments.PoolFragment
-              + GraphQLFragments.AccountCreatedAtFragment
-              + GraphQLFragments.NFTFragment
-              + GraphQLFragments.AddFragment
-              + GraphQLFragments.RemoveFragment
-              + GraphQLFragments.SwapFragment
-              + GraphQLFragments.OrderBookTradeFragment
-              + GraphQLFragments.DepositFragment
-              + GraphQLFragments.WithdrawalFragment
-              + GraphQLFragments.TransferFragment
-              + GraphQLFragments.AccountUpdateFragment
-              + GraphQLFragments.AmmUpdateFragment
-              + GraphQLFragments.SignatureVerificationFragment
-              + GraphQLFragments.TradeNFTFragment
-              + GraphQLFragments.SwapNFTFragment
-              + GraphQLFragments.WithdrawalNFTFragment
-              + GraphQLFragments.TransferNFTFragment
-              + GraphQLFragments.MintNFTFragment
-              + GraphQLFragments.DataNFTFragment;
+              + GraphQLTransactionListFragments.AllFragments;
 
             var request = new RestRequest();
             request.AddHeader("Content-Type", "application/json");
@@ -659,12 +618,8 @@ namespace Lexplorer.Services
                     id
                     __typename
                     block {
-                      id
-                      blockHash
                       timestamp
-                      transactionCount
                     }
-                    data
                     ...AddFragment
                     ...RemoveFragment
                     ...SwapFragment
@@ -680,32 +635,11 @@ namespace Lexplorer.Services
                     ...WithdrawalNFTFragment
                     ...TransferNFTFragment
                     ...MintNFTFragment
-                    ...DataNFTFragment
                   }
                 }
              }
             "
-              + GraphQLFragments.AccountFragment
-              + GraphQLFragments.TokenFragment
-              + GraphQLFragments.PoolFragment
-              + GraphQLFragments.AccountCreatedAtFragment
-              + GraphQLFragments.NFTFragment
-              + GraphQLFragments.AddFragment
-              + GraphQLFragments.RemoveFragment
-              + GraphQLFragments.SwapFragment
-              + GraphQLFragments.OrderBookTradeFragment
-              + GraphQLFragments.DepositFragment
-              + GraphQLFragments.WithdrawalFragment
-              + GraphQLFragments.TransferFragment
-              + GraphQLFragments.AccountUpdateFragment
-              + GraphQLFragments.AmmUpdateFragment
-              + GraphQLFragments.SignatureVerificationFragment
-              + GraphQLFragments.TradeNFTFragment
-              + GraphQLFragments.SwapNFTFragment
-              + GraphQLFragments.WithdrawalNFTFragment
-              + GraphQLFragments.TransferNFTFragment
-              + GraphQLFragments.MintNFTFragment
-              + GraphQLFragments.DataNFTFragment;
+              + GraphQLTransactionListFragments.AllFragments;
 
             var request = new RestRequest();
             request.AddHeader("Content-Type", "application/json");

--- a/Shared/Shared.projitems
+++ b/Shared/Shared.projitems
@@ -28,5 +28,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Services\TransactionExportCointracking.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Services\LoopringPoolTokenCacheService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Models\LoopringPoolToken.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Helpers\GraphQLTransactionListFragments.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
As planned in #177

* using new separate fragments to avoid interference with other detailed queries where fragments might need to contain more
* removed everything from both transactions queries that seemed unused (most notably data - not needed for transaction *list*)