### PR TITLE
Several fixes for misbehaving NFTGrid

### DIFF
--- a/Lexplorer/Components/NFTGrid.razor
+++ b/Lexplorer/Components/NFTGrid.razor
@@ -14,7 +14,7 @@
                                BoundaryCount="1"
                                MiddleCount="1"
                                ShowLastButton="true"
-                               Selected="@PageNumber"
+                               Selected="@_internalPage"
                                Count="@PageCount"
                                SelectedChanged="@((int page) => goToPage(page))" />
             </MudToolBar>
@@ -56,7 +56,7 @@
                                BoundaryCount="1"
                                MiddleCount="1"
                                ShowLastButton="true"
-                               Selected="@PageNumber"
+                               Selected="@_internalPage"
                                Count="@PageCount"
                                SelectedChanged="@((int page) => goToPage(page))" />
             </MudToolBar>
@@ -66,82 +66,96 @@
 </MudGrid>
 
 @code {
+    private int _loadedPage { get; set; } = 0;
+    //for Selected binding of MudPagination, we need update it immediately, but must not update
+    //our PageNumber because it's a [Parameter]
+    private int _internalPage { get; set; } = 1;
+
     [Parameter]
     public int PageNumber { get; set; }
+    [Parameter]
+    public EventCallback<int> PageNumberChanged { get; set; }
 
     [Parameter]
     public int PageCount { get; set; }
 
-    [Parameter]
-    public int PageSize { get; set; }
-
-    [Parameter]
-    public EventCallback<int> PageNumberChanged { get; set; }
-
     public async Task goToPage(int page)
     {
-        PageNumber = page;
-        await PageNumberChanged.InvokeAsync(PageNumber);
+        _internalPage = page;
+        if (PageNumber == page) return;
+        await PageNumberChanged.InvokeAsync(page);
     }
 
     [Parameter]
     public IList<AccountNFTSlot>? NFTSlots { get; set; } = new List<AccountNFTSlot>();
+    private IList<AccountNFTSlot>? _loadedNFTSlots { get; set; }
+
     private Dictionary<string, NftMetadata> NFTdata { get; set; } = new Dictionary<string, NftMetadata>();
     private CancellationTokenSource? cts = null;
 
+    private async Task LoadNFTMetaData(CancellationToken cancellationToken = default)
+    {
+        foreach (var slot in NFTSlots!)
+        {
+            if (slot.nft == null) continue;
+            string nftMetadataLinkCacheKey = $"nftMetadataLink-{slot.nft.nftID}";
+            string? nftMetadataLink = await AppCache.GetOrAddAsyncNonNull(nftMetadataLinkCacheKey,
+                async () => await EthereumService.GetMetadataLink(slot.nft.nftID, slot.nft.token, slot.nft.nftType),
+                DateTimeOffset.UtcNow.AddHours(1));
+            cancellationToken.ThrowIfCancellationRequested();
+            if (string.IsNullOrEmpty(nftMetadataLink)) continue;
+
+            string nftMetadataCacheKey = $"nftMetadata-{nftMetadataLink}";
+            var nftMetadata = await AppCache.GetOrAddAsyncNonNull(nftMetadataCacheKey,
+                async () => await NftMetadataService.GetMetadata(nftMetadataLink, cancellationToken),
+                DateTimeOffset.UtcNow.AddHours(1));
+            cancellationToken.ThrowIfCancellationRequested();
+            if (nftMetadata == null) continue;
+
+            NFTdata.Add(slot.nft.nftID!, nftMetadata);
+            StateHasChanged();
+        }
+    }
+
     protected override async Task OnParametersSetAsync()
     {
-        //cancel any previous OnParametersSetAsync which might still be running
-        cts?.Cancel();
-
-        using (CancellationTokenSource localCTS = new CancellationTokenSource())
+        if ((_loadedPage != PageNumber) && (PageNumber > 0) && (_loadedNFTSlots != NFTSlots) && (NFTSlots != null))
         {
-            //give future calls a chance to cancel us; it is now safe to replace
-            //any previous value of cts, since we already cancelled it above
-            cts = localCTS;
-            try
+            //cancel any previous OnParametersSetAsync which might still be running
+            cts?.Cancel();
+
+            _internalPage = PageNumber;
+            _loadedPage = PageNumber;
+            _loadedNFTSlots = NFTSlots;
+            using (CancellationTokenSource localCTS = new CancellationTokenSource())
             {
-                NFTdata = new Dictionary<string, NftMetadata>();
-                if (NFTSlots != null)
+                //give future calls a chance to cancel us; it is now safe to replace
+                //any previous value of cts, since we already cancelled it above
+                cts = localCTS;
+                try
                 {
-                    StateHasChanged();
-                    foreach (var slot in NFTSlots!)
-                    {
-                        if (slot.nft == null) continue;
-                        string nftMetadataLinkCacheKey = $"nftMetadataLink-{slot.nft.nftID}";
-                        string? nftMetadataLink = await AppCache.GetOrAddAsyncNonNull(nftMetadataLinkCacheKey,
-                            async () => await EthereumService.GetMetadataLink(slot.nft.nftID, slot.nft.token, slot.nft.nftType),
-                            DateTimeOffset.UtcNow.AddHours(1));
-                        if (string.IsNullOrEmpty(nftMetadataLink)) continue;
-
-                        string nftMetadataCacheKey = $"nftMetadata-{nftMetadataLink}";
-                        var nftMetadata = await AppCache.GetOrAddAsyncNonNull(nftMetadataCacheKey,
-                            async () => await NftMetadataService.GetMetadata(nftMetadataLink, localCTS.Token),
-                            DateTimeOffset.UtcNow.AddHours(1));
-                        localCTS.Token.ThrowIfCancellationRequested();
-                        if (nftMetadata == null) continue;
-
-                        NFTdata.Add(slot.nft.nftID!, nftMetadata);
-                        StateHasChanged();
-                    }
+                    NFTdata = new Dictionary<string, NftMetadata>();
+                    await LoadNFTMetaData(localCTS.Token);
                 }
+                catch (OperationCanceledException)
+                {
+                }
+                catch (Exception e)
+                {
+                    Trace.WriteLine(e.StackTrace + "\n" + e.Message);
+                }
+                //now for cleanup, we must clear cts, but only if it is still our localCTS, which we're about to dispose
+                //otherwise a new call has already replaced cts with it's own localCTS
+                Interlocked.CompareExchange<CancellationTokenSource?>(ref cts, null, localCTS);
             }
-            catch (OperationCanceledException)
-            {
-            }
-            catch (Exception e)
-            {
-                Trace.WriteLine(e.StackTrace + "\n" + e.Message);
-            }
-            //now for cleanup, we must clear cts, but only if it is still our localCTS, which we're about to dispose
-            //otherwise a new call has already replaced cts with it's own localCTS
-            Interlocked.CompareExchange<CancellationTokenSource?>(ref cts, null, localCTS);
         }
     }
 
     public void Dispose()
     {
         cts?.Cancel();
+        cts?.Dispose();
+        cts = null;
     }
 
     private NftMetadata? GetMetadata(string? nftID)

--- a/Lexplorer/Pages/AccountDetails.razor
+++ b/Lexplorer/Pages/AccountDetails.razor
@@ -75,7 +75,7 @@
             </MudTable>
         </MudTabPanel>
         <MudTabPanel Text="NFTs">
-            <NFTGrid @bind-PageNumber="@gotoNFTPage" NFTSlots="@accountNFTSlots" PageSize="@nftPageSize" PageCount="@nftPages" />
+            <NFTGrid @bind-PageNumber="@gotoNFTPage" NFTSlots="@accountNFTSlots" PageCount="@nftPages" />
         </MudTabPanel>
     </MudTabs>
 
@@ -146,8 +146,8 @@
         }
         set
         {
-            nftPageNumber = value.ToString(); //set immediately for MudPagination to not switch forth and back
-            string URL = $"/account/{accountId}?pageNumber={pageNumber}&nftPageNumber={value}";
+            if (gotoNFTPage == value) return;
+            var URL = NavigationManager.GetUriWithQueryParameter(nameof(nftPageNumber), value.ToString());
             NavigationManager.NavigateTo(URL);
         }
     }
@@ -162,7 +162,7 @@
     private Account? account { get; set; }
     private LoopringPoolToken? poolToken { get; set; }
     private IList<Transaction>? transactions { get; set; } = new List<Transaction>();
-    private IList<AccountNFTSlot> accountNFTSlots { get; set; } = new List<AccountNFTSlot>();
+    private IList<AccountNFTSlot>? accountNFTSlots { get; set; }
     private CancellationTokenSource? cts;
 
     protected override async Task OnParametersSetAsync()
@@ -183,7 +183,7 @@
                 {
                     account = null;
                     transactions = new List<Transaction>();
-                    accountNFTSlots = new List<AccountNFTSlot>();
+                    accountNFTSlots = null;
                     pageNumber = "1";
                     nftPageNumber = "1";
                     StateHasChanged();

--- a/Lexplorer/Pages/NFTCollection.razor
+++ b/Lexplorer/Pages/NFTCollection.razor
@@ -11,7 +11,7 @@
 <MudContainer Fixed="true" Class="px-0 extra-extra-extra-large">
     <MudText Typo="Typo.h6">NFT Contract Address <L1AccountLink address="@tokenAddress" shortenAddress="false" /></MudText>
     <br />
-    <NFTGrid @bind-PageNumber="@goToPage" NFTSlots="@collectionNFTSlots" PageSize="@pageSize" PageCount="@maxPageCount" />
+    <NFTGrid @bind-PageNumber="@goToPage" NFTSlots="@collectionNFTSlots" PageCount="@maxPageCount" />
 </MudContainer>
 
 @code {
@@ -30,7 +30,6 @@
         }
         set
         {
-            pageNumber = value.ToString(); //set immediately for NFTGrid to not switch forth and back
             var URL = NavigationManager.GetUriWithQueryParameter(nameof(pageNumber), value);
             NavigationManager.NavigateTo(URL);
         }
@@ -41,7 +40,7 @@
     public int maxPageCount { get; set; } = 1;
 
     private CancellationTokenSource? cts;
-    private IList<AccountNFTSlot>? collectionNFTSlots { get; set; } = new List<AccountNFTSlot>();
+    private IList<AccountNFTSlot>? collectionNFTSlots { get; set; }
     protected override async Task OnParametersSetAsync()
     {
         //quickly and early ensure that maxPageCount never get's smaller than the page we're on
@@ -68,8 +67,7 @@
 
                 //transform list of nfts to list of accountsSlots with everything else empty/null
                 collectionNFTSlots = collectionNFTs?.
-                    Select(NFT => new AccountNFTSlot() { nft = NFT }).ToList() ??
-                    new List<AccountNFTSlot>();
+                    Select(NFT => new AccountNFTSlot() { nft = NFT }).ToList();
             }
             catch (OperationCanceledException)
             {


### PR DESCRIPTION
Follow-up for #195 after discovering several issue

* remove unused PageSize parameter
* follow top-down parameter rule, a component should never change
  it's own parameters, that is always the task of the parent
  * use _internalPage for binding to MudPagination
  * that way we can make it happy, by setting it directly in gotoPage
    to avoid it switching back and forth
* we need PageNumber *and* the NFTSlots to reliably load the metadata
  * but any and each parameter change will tricker OnParameterSetAsync
  * to determine when we're actually ready to load a new NFTdata
    collection we need to store for what page and slots we loaded last
  * this requires that AccountDetails and NFTCollection pages never
    use empty NFTSlots as intermediary, because the NFTGrid has no
    way of knowing whether this is the real slots
* cts should also be disposed in Dispose, if present