### PR TITLE
Crop NFT description after 3 lines

### DIFF
--- a/Lexplorer/Components/NFTGrid.razor
+++ b/Lexplorer/Components/NFTGrid.razor
@@ -34,7 +34,7 @@
                         { 
                             <MudChip Label="true" Color="Color.Primary" Class="ml-0">x @slot.balance.ToString("#,##0")</MudChip>
                         }
-                        <MudText Typo="Typo.body2">@metaData?.description</MudText>
+                        <MudText Typo="Typo.body2" Class="crop-text">@metaData?.description</MudText>
                     </MudCardContent>
                     <MudCardActions>
                         <MudButton Style="position:absolute;bottom:0;"
@@ -169,3 +169,11 @@
     }
 }
 
+<style>
+    .crop-text {
+        display: -webkit-box;
+        -webkit-line-clamp: 3;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+    }
+</style>


### PR DESCRIPTION
Fixes #199

* locally defines the style since only used here for now

From what I understand, we should be safe to use [`-webkit-line-clamp`](https://caniuse.com/?search=-webkit-line-clamp).

Screenshot on macOS with Safari:

<img width="1094" alt="image" src="https://user-images.githubusercontent.com/44807458/176625251-d30851c6-b902-4f39-bd92-d8537334a00d.png">

Same NFT on mobile fits into 3 lines, so it isn't cropped:

<img width="396" alt="image" src="https://user-images.githubusercontent.com/44807458/176625503-dff0d1ab-5617-4406-9815-cb3ee4931229.png">
