### PR TITLE
Show NFT collection meta data

### DIFF
--- a/Lexplorer/Components/NFTGrid.razor
+++ b/Lexplorer/Components/NFTGrid.razor
@@ -93,26 +93,34 @@
     private Dictionary<string, NftMetadata> NFTdata { get; set; } = new Dictionary<string, NftMetadata>();
     private CancellationTokenSource? cts = null;
 
-    private async Task LoadNFTMetaData(CancellationToken cancellationToken = default)
+    public async Task<NftMetadata?> LoadNFTMetaData(AccountNFTSlot? slot, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(slot?.nft?.nftID)) return null;
+
+        string nftMetadataLinkCacheKey = $"nftMetadataLink-{slot.nft.nftID}";
+        string? nftMetadataLink = await AppCache.GetOrAddAsyncNonNull(nftMetadataLinkCacheKey,
+            async () => await EthereumService.GetMetadataLink(slot.nft.nftID, slot.nft.token, slot.nft.nftType),
+            DateTimeOffset.UtcNow.AddHours(1));
+        cancellationToken.ThrowIfCancellationRequested();
+        if (string.IsNullOrEmpty(nftMetadataLink)) return null;
+
+        string nftMetadataCacheKey = $"nftMetadata-{nftMetadataLink}";
+        var nftMetadata = await AppCache.GetOrAddAsyncNonNull(nftMetadataCacheKey,
+            async () => await NftMetadataService.GetMetadata(nftMetadataLink, cancellationToken),
+            DateTimeOffset.UtcNow.AddHours(1));
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return nftMetadata;
+    }
+
+    private async Task LoadAllNFTMetaData(CancellationToken cancellationToken = default)
     {
         foreach (var slot in NFTSlots!)
         {
-            if (slot.nft == null) continue;
-            string nftMetadataLinkCacheKey = $"nftMetadataLink-{slot.nft.nftID}";
-            string? nftMetadataLink = await AppCache.GetOrAddAsyncNonNull(nftMetadataLinkCacheKey,
-                async () => await EthereumService.GetMetadataLink(slot.nft.nftID, slot.nft.token, slot.nft.nftType),
-                DateTimeOffset.UtcNow.AddHours(1));
-            cancellationToken.ThrowIfCancellationRequested();
-            if (string.IsNullOrEmpty(nftMetadataLink)) continue;
-
-            string nftMetadataCacheKey = $"nftMetadata-{nftMetadataLink}";
-            var nftMetadata = await AppCache.GetOrAddAsyncNonNull(nftMetadataCacheKey,
-                async () => await NftMetadataService.GetMetadata(nftMetadataLink, cancellationToken),
-                DateTimeOffset.UtcNow.AddHours(1));
-            cancellationToken.ThrowIfCancellationRequested();
+            var nftMetadata = await LoadNFTMetaData(slot, cancellationToken);
             if (nftMetadata == null) continue;
 
-            NFTdata.Add(slot.nft.nftID!, nftMetadata);
+            NFTdata.Add(slot!.nft!.nftID!, nftMetadata);
             StateHasChanged();
         }
     }
@@ -135,7 +143,7 @@
                 try
                 {
                     NFTdata = new Dictionary<string, NftMetadata>();
-                    await LoadNFTMetaData(localCTS.Token);
+                    await LoadAllNFTMetaData(localCTS.Token);
                 }
                 catch (OperationCanceledException)
                 {

--- a/Lexplorer/Pages/NFTCollection.razor
+++ b/Lexplorer/Pages/NFTCollection.razor
@@ -5,16 +5,72 @@
 @inject NftMetadataService NftMetadataService;
 @inject NavigationManager NavigationManager;
 @inject IAppCache AppCache;
+@inject IDialogService DialogService;
 
 <PageTitle>The Lexplorer - NFT Collection</PageTitle>
 
 <MudContainer Fixed="true" Class="px-0 extra-extra-extra-large">
-    <MudText Typo="Typo.h6">NFT Contract Address <L1AccountLink address="@tokenAddress" shortenAddress="false" /></MudText>
+    <MudSimpleTable Dense="true" Striped="true" Bordered="true">
+        <tbody>
+            <tr>
+                <td colspan="2">
+                    <div class="mud-toolbar mud-toolbar-gutters mud-table-toolbar">
+                        <MudText Typo="Typo.h6">@($"NFT collection: {collectionMetadata?.name ?? tokenAddress}")</MudText>
+                    </div>
+                </td>
+            </tr>
+            <tr>
+                <td>Contract address</td>
+                <td><L1AccountLink address="@tokenAddress" shortenAddress="false" /></td>
+            </tr>
+            @if (collectionMetadata != null)
+            {
+                <tr>
+                    <td>Description</td>
+                    <td>@collectionMetadata?.description</td>
+                </tr>
+                <tr>
+                    <td>Thumbnail</td>
+                    <td Style="word-break:break-all;">@collectionMetadata?.thumbnail_uri</td>
+                </tr>
+                <tr>
+                    <td>Banner</td>
+                    <td Style="word-break:break-all;">@collectionMetadata?.banner_uri</td>
+                </tr>
+                <tr>
+                    <td>Avatar</td>
+                    <td Style="word-break:break-all;">@collectionMetadata?.avatar_uri</td>
+                </tr>
+                <tr>
+                    <td>Tile</td>
+                    <td Style="word-break:break-all;">@collectionMetadata?.tile_uri</td>
+                </tr>
+                <tr>
+                    <td colspan="2">
+                        <img src="@NftMetadataService.MakeIPFSLink(collectionMetadata?.thumbnail_uri)" class="nft" />
+                    </td>
+                </tr>
+            }
+            @if ((collectionMetadata?.JSONContent) != null)
+            {
+                <tr>
+                    <td colspan="2">
+                        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="showJSON" Class="mr-2">View Metadata</MudButton>
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </MudSimpleTable>
+
     <br />
-    <NFTGrid @bind-PageNumber="@goToPage" NFTSlots="@collectionNFTSlots" PageCount="@maxPageCount" />
+
+    <br />
+    <NFTGrid @ref="nftGrid" @bind-PageNumber="@goToPage" NFTSlots="@collectionNFTSlots" PageCount="@maxPageCount" />
 </MudContainer>
 
 @code {
+    private NFTGrid nftGrid = default!;
+
     [Parameter]
     public string? tokenAddress { get; set; }
 
@@ -41,6 +97,8 @@
 
     private CancellationTokenSource? cts;
     private IList<AccountNFTSlot>? collectionNFTSlots { get; set; }
+    private NftCollectionMetadata? collectionMetadata { get; set; }
+
     protected override async Task OnParametersSetAsync()
     {
         //quickly and early ensure that maxPageCount never get's smaller than the page we're on
@@ -68,6 +126,17 @@
                 //transform list of nfts to list of accountsSlots with everything else empty/null
                 collectionNFTSlots = collectionNFTs?.
                     Select(NFT => new AccountNFTSlot() { nft = NFT }).ToList();
+                StateHasChanged();
+
+                var metaData = await nftGrid.LoadNFTMetaData(collectionNFTSlots!.FirstOrDefault());
+                if (string.IsNullOrEmpty(metaData?.collection_metadata)) return;
+
+                string collectionMetaDataKey = $"collectionMetadata-{tokenAddress}";
+                collectionMetadata = await AppCache.GetOrAddAsyncNonNull(collectionNftKey,
+                    async () => await NftMetadataService.GetCollectionMetadata(metaData.collection_metadata!, cancellationToken: localCTS.Token),
+                    DateTimeOffset.UtcNow.AddMinutes(10));
+                localCTS.Token.ThrowIfCancellationRequested();
+                StateHasChanged();
             }
             catch (OperationCanceledException)
             {
@@ -82,4 +151,14 @@
         }
     }
 
- }
+    public void showJSON()
+    {
+        var parameters = new DialogParameters();
+        parameters.Add("JSON", collectionMetadata?.JSONContent);
+
+        var options = new DialogOptions() { CloseButton = true, MaxWidth = MaxWidth.Medium, FullWidth = true };
+
+        DialogService.Show<NFTMetadataDialog>("NFT collection metadata JSON", parameters, options);
+    }
+
+}

--- a/Shared/Models/NftMetadata.cs
+++ b/Shared/Models/NftMetadata.cs
@@ -13,6 +13,9 @@ namespace Lexplorer.Models
         public string? animation_url { get; set; }
         public string? contentType { get; set; }
 
+        //found with GME minted NFTs
+        public string? collection_metadata { get; set; }
+
         public List<NftAttribute>? attributes { get; set; }
 
         public string? JSONContent { get; set; }
@@ -22,5 +25,18 @@ namespace Lexplorer.Models
     {
         public string? trait_type { get; set; }
         public object? value { get; set; } //value can be either string or int
+    }
+
+    public class NftCollectionMetadata
+    {
+        public string? name { get; set; }
+        public string? description { get; set; }
+
+        public string? thumbnail_uri { get; set; }
+        public string? banner_uri { get; set; }
+        public string? avatar_uri { get; set; }
+        public string? tile_uri { get; set; }
+
+        public string? JSONContent { get; set; }
     }
 }

--- a/Shared/Services/NftMetadataService.cs
+++ b/Shared/Services/NftMetadataService.cs
@@ -42,6 +42,26 @@ namespace Lexplorer.Services
             return link.StartsWith("ipfs://") ? _ipfsBaseUrl + link.Remove(0, 7) : link; //remove the ipfs portion and add base
         }
 
+        public async Task<NftCollectionMetadata?> GetCollectionMetadata(string URL, CancellationToken cancellationToken = default)
+        {
+            var request = new RestRequest(URL);
+            try
+            {
+                request.Timeout = 10000; //we can't afford to wait forever here, 10s must be enough
+                var response = await _client.GetAsync(request, cancellationToken);
+                var token = JToken.Parse(response.Content!);
+                var metadata = token.ToObject<NftCollectionMetadata>();
+                if ((token != null) && (metadata != null))
+                    metadata.JSONContent = token.ToString(Formatting.Indented);
+                return metadata;
+            }
+            catch (Exception e)
+            {
+                Trace.WriteLine(e.StackTrace + "\n" + e.Message);
+                return null;
+            }
+        }
+
         public async Task<NftMetadata?> GetMetadata(string link, CancellationToken cancellationToken = default)
         {
             link = MakeIPFSLink(link)!;


### PR DESCRIPTION
Closes #203 

If metadata is present, shows it similar to NFT details, including thumbnail preview and view metadata button:

<img width="1152" alt="image" src="https://user-images.githubusercontent.com/44807458/176904877-82e77763-f217-4910-abde-c0bf5f654fba.png">

* refactored NFTGrid so LoadMetaData can be called
  * not moved to a service, since we want app cache usage
* added collection details to page if present - identical to NFT
  detail page where possible
* showing image of thumbnail_uri
* added View Metadata button too
* simple GetCollectionMetadata - no ipfs link handling etc. for now