### PR TITLE
Move from Tabs to Expansions Panels

### DIFF
--- a/Lexplorer/Components/LexpansionPanel.razor
+++ b/Lexplorer/Components/LexpansionPanel.razor
@@ -1,0 +1,23 @@
+﻿
+<MudExpansionPanel Text="@Text" DisableGutters="true" @bind-IsExpanded="isOpen" HideIcon="true">
+    <TitleContent>
+        <div class="d-flex">
+            <MudIcon Icon="@(isOpen ? Icons.Material.Filled.KeyboardArrowUp : Icons.Material.Filled.KeyboardArrowDown)" class="mr-3"></MudIcon>
+            <MudText>@Text</MudText>
+        </div>
+    </TitleContent>
+    <ChildContent>
+        @ChildContent
+    </ChildContent>
+</MudExpansionPanel>
+
+@code {
+    private bool isOpen = false;
+
+    [Parameter]
+    public string Text { get; set; } = "";
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+}
+

--- a/Lexplorer/Components/NFTGrid.razor
+++ b/Lexplorer/Components/NFTGrid.razor
@@ -8,17 +8,13 @@
 
 <MudGrid>
     <MudItem xs="12" Class="d-flex justify-center">
-        <MudPaper Width="100%">
-            <MudToolBar Class="justify-center">
-                <MudPagination Size="Size.Small" ShowFirstButton="true"
+        <MudPagination Size="Size.Small" ShowFirstButton="true" Class="justify-center"
                                BoundaryCount="1"
                                MiddleCount="1"
                                ShowLastButton="true"
                                Selected="@_internalPage"
                                Count="@PageCount"
                                SelectedChanged="@((int page) => goToPage(page))" />
-            </MudToolBar>
-        </MudPaper>
     </MudItem>
     @if (NFTSlots != null && NFTSlots.Count > 0)
     {
@@ -50,19 +46,16 @@
         <MudText class="pa-3">No NFTs</MudText>
     }
     <MudHidden Breakpoint="Breakpoint.MdAndDown" Invert="true">
-        <MudPaper Width="100%" Class="mx-4">
-            <MudToolBar Class="justify-center">
-                <MudPagination Size="Size.Small" ShowFirstButton="true"
-                               BoundaryCount="1"
-                               MiddleCount="1"
-                               ShowLastButton="true"
-                               Selected="@_internalPage"
-                               Count="@PageCount"
-                               SelectedChanged="@((int page) => goToPage(page))" />
-            </MudToolBar>
-        </MudPaper>
+        <MudItem xs="12" Class="d-flex justify-center">
+            <MudPagination Size="Size.Small" ShowFirstButton="true" Class="justify-center"
+                                   BoundaryCount="1"
+                                   MiddleCount="1"
+                                   ShowLastButton="true"
+                                   Selected="@_internalPage"
+                                   Count="@PageCount"
+                                   SelectedChanged="@((int page) => goToPage(page))" />
+        </MudItem>
     </MudHidden>
-    <MudDivider DividerType="DividerType.Middle" Class="my-6" />
 </MudGrid>
 
 @code {

--- a/Lexplorer/Pages/AccountDetails.razor
+++ b/Lexplorer/Pages/AccountDetails.razor
@@ -55,13 +55,7 @@
 
     <br />
     <MudExpansionPanels MultiExpansion="true">
-        <MudExpansionPanel Text="Token Balances" DisableGutters="true" @bind-IsExpanded="tokenIsOpen" HideIcon="true">
-            <TitleContent>
-                <div class="d-flex">
-                    <MudIcon Icon="@(tokenIsOpen ? Icons.Material.Filled.KeyboardArrowUp : Icons.Material.Filled.KeyboardArrowDown)" class="mr-3"></MudIcon>
-                    <MudText>Token Balances</MudText>
-                </div>
-            </TitleContent>
+        <LexpansionPanel Text="Token Balances">
             <ChildContent>
                 <MudTable Dense="true" Striped="true" Bordered="true" Items="@account?.balances" Hover="true" Loading=@balancesLoading >
                     <HeaderContent>
@@ -80,14 +74,8 @@
                     </PagerContent>
                 </MudTable>
             </ChildContent>
-        </MudExpansionPanel>
-        <MudExpansionPanel Text="Transactions" DisableGutters="true" @bind-IsExpanded="txIsOpen" HideIcon="true">
-            <TitleContent>
-                <div class="d-flex">
-                    <MudIcon Icon="@(txIsOpen ? Icons.Material.Filled.KeyboardArrowUp : Icons.Material.Filled.KeyboardArrowDown)" class="mr-3"></MudIcon>
-                    <MudText>Transactions</MudText>
-                </div>
-            </TitleContent>
+        </LexpansionPanel>
+        <LexpansionPanel Text="Transactions">
             <ChildContent>
                 <MudTable Dense="true" Striped="true" Bordered="true" Items="@transactions" Hover="true" Loading=@isLoading>
                     <ToolBarContent>
@@ -119,18 +107,12 @@
                     </RowTemplate>
                 </MudTable>
             </ChildContent>
-        </MudExpansionPanel>
-        <MudExpansionPanel Text="NFTs" DisableGutters="true" @bind-IsExpanded="nftIsOpen" HideIcon="true">
-            <TitleContent>
-                <div class="d-flex">
-                    <MudIcon Icon="@(nftIsOpen ? Icons.Material.Filled.KeyboardArrowUp : Icons.Material.Filled.KeyboardArrowDown)" class="mr-3"></MudIcon>
-                    <MudText>NFTs</MudText>
-                </div>
-            </TitleContent>
+        </LexpansionPanel>
+        <LexpansionPanel Text="NFTs">
             <ChildContent>
                 <NFTGrid @bind-PageNumber="@gotoNFTPage" NFTSlots="@accountNFTSlots" PageCount="@nftPages" />
             </ChildContent>
-        </MudExpansionPanel>
+        </LexpansionPanel>
     </MudExpansionPanels>
     <br />
 
@@ -176,9 +158,6 @@
         }
     }
 
-    bool tokenIsOpen;
-    bool txIsOpen;
-    bool nftIsOpen;
     public bool balancesLoading;
     public bool isLoading = true;
     public readonly int pageSize = 25;

--- a/Lexplorer/Pages/AccountDetails.razor
+++ b/Lexplorer/Pages/AccountDetails.razor
@@ -57,7 +57,7 @@
     <MudExpansionPanels MultiExpansion="true">
         <LexpansionPanel Text="Token Balances">
             <ChildContent>
-                <MudTable Dense="true" Striped="true" Bordered="true" Items="@account?.balances" Hover="true" Loading=@balancesLoading >
+                <MudTable Dense="true" Striped="true" Bordered="true" Items="@account?.balances" Hover="true" Loading=@balancesLoading>
                     <HeaderContent>
                         <MudTh Style="text-align:right"><MudTableSortLabel SortBy="new Func<AccountTokenBalance, object>(x=>x.token!.name!)">Token</MudTableSortLabel></MudTh>
                         <MudTh><MudTableSortLabel SortBy="new Func<AccountTokenBalance, object>(x=>x.fBalance!)">Balance</MudTableSortLabel></MudTh>
@@ -73,6 +73,11 @@
                         }
                     </PagerContent>
                 </MudTable>
+            </ChildContent>
+        </LexpansionPanel>
+        <LexpansionPanel Text="NFTs">
+            <ChildContent>
+                <NFTGrid @bind-PageNumber="@gotoNFTPage" NFTSlots="@accountNFTSlots" PageCount="@nftPages" />
             </ChildContent>
         </LexpansionPanel>
         <LexpansionPanel Text="Transactions">
@@ -106,11 +111,6 @@
                         <MudTd DataLabel="Timestamp">@context.verifiedAt</MudTd>
                     </RowTemplate>
                 </MudTable>
-            </ChildContent>
-        </LexpansionPanel>
-        <LexpansionPanel Text="NFTs">
-            <ChildContent>
-                <NFTGrid @bind-PageNumber="@gotoNFTPage" NFTSlots="@accountNFTSlots" PageCount="@nftPages" />
             </ChildContent>
         </LexpansionPanel>
     </MudExpansionPanels>

--- a/Lexplorer/Pages/AccountDetails.razor
+++ b/Lexplorer/Pages/AccountDetails.razor
@@ -54,62 +54,86 @@
     </MudSimpleTable>
 
     <br />
-
-    <MudTabs>
-        <MudTabPanel Text="Token balances">
-            <MudTable Dense="true" Striped="true" Bordered="true" Items="@account?.balances" Hover="true" Loading=@balancesLoading>
-                <HeaderContent>
-                    <MudTh Style="text-align:right"><MudTableSortLabel SortBy="new Func<AccountTokenBalance, object>(x=>x.token!.name!)">Token</MudTableSortLabel></MudTh>
-                    <MudTh><MudTableSortLabel SortBy="new Func<AccountTokenBalance, object>(x=>x.fBalance!)">Balance</MudTableSortLabel></MudTh>
-                </HeaderContent>
-                <RowTemplate>
-                    <MudTd Style="text-align:right" DataLabel="Token">@context.token!.name</MudTd>
-                    <MudTd DataLabel="Balance">@TokenAmountConverter.ToString(context.balance, context.token!.decimals) @context.token.symbol</MudTd>
-                </RowTemplate>
-                <PagerContent>
-                    @if (account?.balances?.Count > 10)
-                    {
-                        <MudTablePager InfoFormat="@("{first_item}-{last_item} of {all_items}")" HorizontalAlignment="HorizontalAlignment.Left" />
-                    }
-                </PagerContent>
-            </MudTable>
-        </MudTabPanel>
-        <MudTabPanel Text="NFTs">
-            <NFTGrid @bind-PageNumber="@gotoNFTPage" NFTSlots="@accountNFTSlots" PageCount="@nftPages" />
-        </MudTabPanel>
-    </MudTabs>
-
+    <MudExpansionPanels MultiExpansion="true">
+        <MudExpansionPanel Text="Token Balances" DisableGutters="true" @bind-IsExpanded="tokenIsOpen" HideIcon="true">
+            <TitleContent>
+                <div class="d-flex">
+                    <MudIcon Icon="@(tokenIsOpen ? Icons.Material.Filled.KeyboardArrowUp : Icons.Material.Filled.KeyboardArrowDown)" class="mr-3"></MudIcon>
+                    <MudText>Token Balances</MudText>
+                </div>
+            </TitleContent>
+            <ChildContent>
+                <MudTable Dense="true" Striped="true" Bordered="true" Items="@account?.balances" Hover="true" Loading=@balancesLoading >
+                    <HeaderContent>
+                        <MudTh Style="text-align:right"><MudTableSortLabel SortBy="new Func<AccountTokenBalance, object>(x=>x.token!.name!)">Token</MudTableSortLabel></MudTh>
+                        <MudTh><MudTableSortLabel SortBy="new Func<AccountTokenBalance, object>(x=>x.fBalance!)">Balance</MudTableSortLabel></MudTh>
+                    </HeaderContent>
+                    <RowTemplate>
+                        <MudTd Style="text-align:right" DataLabel="Token">@context.token!.name</MudTd>
+                        <MudTd DataLabel="Balance">@TokenAmountConverter.ToString(context.balance, context.token!.decimals) @context.token.symbol</MudTd>
+                    </RowTemplate>
+                    <PagerContent>
+                        @if (account?.balances?.Count > 10)
+                        {
+                            <MudTablePager InfoFormat="@("{first_item}-{last_item} of {all_items}")" HorizontalAlignment="HorizontalAlignment.Left" />
+                        }
+                    </PagerContent>
+                </MudTable>
+            </ChildContent>
+        </MudExpansionPanel>
+        <MudExpansionPanel Text="Transactions" DisableGutters="true" @bind-IsExpanded="txIsOpen" HideIcon="true">
+            <TitleContent>
+                <div class="d-flex">
+                    <MudIcon Icon="@(txIsOpen ? Icons.Material.Filled.KeyboardArrowUp : Icons.Material.Filled.KeyboardArrowDown)" class="mr-3"></MudIcon>
+                    <MudText>Transactions</MudText>
+                </div>
+            </TitleContent>
+            <ChildContent>
+                <MudTable Dense="true" Striped="true" Bordered="true" Items="@transactions" Hover="true" Loading=@isLoading>
+                    <ToolBarContent>
+                        <MudText Typo="Typo.h6" Class="d-none d-sm-flex">Transactions</MudText>
+                        <MudText Typo="Typo.h6" Class="d-flex d-sm-none d-xs-none">Tx's</MudText>
+                        <MudSpacer />
+                        <MudIconButton Icon="@Icons.Filled.FirstPage" Disabled=@(gotoPage == 1) OnClick="@(() => gotoPage = 1)" />
+                        <MudIconButton Icon="@Icons.Filled.NavigateBefore" Disabled=@(gotoPage == 1) OnClick="@(() => gotoPage -= 1)" />
+                        <MudNumericField HideSpinButtons="true" @bind-Value="gotoPage" Label="Page" Variant="Variant.Outlined" Min="1" Margin="Margin.Dense" Class="flex-grow-0" Style="width:50px;" />
+                        <MudIconButton Icon="@Icons.Filled.NavigateNext" Disabled=@(transactions!.Count < pageSize) OnClick="@(() => gotoPage += 1)" />
+                        <MudSpacer />
+                        <MudIconButton Icon="@Icons.Filled.Download" OnClick="ShowCSVOptions" />
+                    </ToolBarContent>
+                    <HeaderContent>
+                        <MudTh>Tx Id</MudTh>
+                        <MudTh>Type</MudTh>
+                        <MudTh>From</MudTh>
+                        <MudTh>To</MudTh>
+                        <MudTh Style="text-align:right">Bought</MudTh>
+                        <MudTh Style="text-align:right">Sold</MudTh>
+                        <MudTh Style="text-align:right">Fee</MudTh>
+                        <MudTh>Verified At (UTC)</MudTh>
+                    </HeaderContent>
+                    <RowTemplate>
+                        <MudTd DataLabel="Transaction Id">@LinkHelper.GetObjectLink(context)</MudTd>
+                        <MudTd DataLabel="Type">@context.typeName</MudTd>
+                        <TransactionTableDetails TransactionData=@context ignoreUserIDForLink=@accountId />
+                        <MudTd DataLabel="Timestamp">@context.verifiedAt</MudTd>
+                    </RowTemplate>
+                </MudTable>
+            </ChildContent>
+        </MudExpansionPanel>
+        <MudExpansionPanel Text="NFTs" DisableGutters="true" @bind-IsExpanded="nftIsOpen" HideIcon="true">
+            <TitleContent>
+                <div class="d-flex">
+                    <MudIcon Icon="@(nftIsOpen ? Icons.Material.Filled.KeyboardArrowUp : Icons.Material.Filled.KeyboardArrowDown)" class="mr-3"></MudIcon>
+                    <MudText>NFTs</MudText>
+                </div>
+            </TitleContent>
+            <ChildContent>
+                <NFTGrid @bind-PageNumber="@gotoNFTPage" NFTSlots="@accountNFTSlots" PageCount="@nftPages" />
+            </ChildContent>
+        </MudExpansionPanel>
+    </MudExpansionPanels>
     <br />
 
-    <MudTable Dense="true" Striped="true" Bordered="true" Items="@transactions" Hover="true" Loading=@isLoading>
-        <ToolBarContent>
-            <MudText Typo="Typo.h6" Class="d-none d-sm-flex">Transactions</MudText>
-            <MudText Typo="Typo.h6" Class="d-flex d-sm-none d-xs-none">Tx's</MudText>
-            <MudSpacer />
-            <MudIconButton Icon="@Icons.Filled.FirstPage" Disabled=@(gotoPage == 1) OnClick="@(() => gotoPage = 1)" />
-            <MudIconButton Icon="@Icons.Filled.NavigateBefore" Disabled=@(gotoPage == 1) OnClick="@(() => gotoPage -= 1)" />
-            <MudNumericField HideSpinButtons="true" @bind-Value="gotoPage" Label="Page" Variant="Variant.Outlined" Min="1" Margin="Margin.Dense" Class="flex-grow-0" Style="width:50px;" />
-            <MudIconButton Icon="@Icons.Filled.NavigateNext" Disabled=@(transactions!.Count < pageSize) OnClick="@(() => gotoPage += 1)" />
-            <MudSpacer />
-            <MudIconButton Icon="@Icons.Filled.Download" OnClick="ShowCSVOptions" />
-        </ToolBarContent>
-        <HeaderContent>
-            <MudTh>Tx Id</MudTh>
-            <MudTh>Type</MudTh>
-            <MudTh>From</MudTh>
-            <MudTh>To</MudTh>
-            <MudTh Style="text-align:right">Bought</MudTh>
-            <MudTh Style="text-align:right">Sold</MudTh>
-            <MudTh Style="text-align:right">Fee</MudTh>
-            <MudTh>Verified At (UTC)</MudTh>
-        </HeaderContent>
-        <RowTemplate>
-            <MudTd DataLabel="Transaction Id">@LinkHelper.GetObjectLink(context)</MudTd>
-            <MudTd DataLabel="Type">@context.typeName</MudTd>
-            <TransactionTableDetails TransactionData=@context ignoreUserIDForLink=@accountId />
-            <MudTd DataLabel="Timestamp">@context.verifiedAt</MudTd>
-        </RowTemplate>
-    </MudTable>
 </MudContainer>
 
 
@@ -152,6 +176,9 @@
         }
     }
 
+    bool tokenIsOpen;
+    bool txIsOpen;
+    bool nftIsOpen;
     public bool balancesLoading;
     public bool isLoading = true;
     public readonly int pageSize = 25;

--- a/Lexplorer/Pages/NFTDetail.razor
+++ b/Lexplorer/Pages/NFTDetail.razor
@@ -104,57 +104,72 @@
 </MudSimpleTable>
 
 <br />
-
-<MudTable Dense="true" Striped="true" Bordered="true" Items="@transactions" Hover="true" Loading=@isLoading>
-    <ToolBarContent>
-        <MudText Typo="Typo.h6">Transactions</MudText>
-        <MudSpacer />
-        <MudIconButton Icon="@Icons.Filled.FirstPage" Disabled=@(gotoPage == 1) OnClick="@(() => gotoPage = 1)" />
-        <MudIconButton Icon="@Icons.Filled.NavigateBefore" Disabled=@(gotoPage == 1) OnClick="@(() => gotoPage -= 1)" />
-        <MudNumericField HideSpinButtons="true" @bind-Value="gotoPage" Label="Page" Variant="Variant.Outlined" Min="1" Margin="Margin.Dense" Class="flex-grow-0" Style="width:50px;" />
-        <MudIconButton Icon="@Icons.Filled.NavigateNext" Disabled=@(transactions!.Count < pageSize) OnClick="@(() => gotoPage += 1)" />
-        <MudSpacer />
-    </ToolBarContent>
-    <HeaderContent>
-        <MudTh>Tx Id</MudTh>
-        <MudTh>Type</MudTh>
-        <MudTh>From</MudTh>
-        <MudTh>To</MudTh>
-        <MudTh Style="text-align:right">Bought</MudTh>
-        <MudTh Style="text-align:right">Sold</MudTh>
-        <MudTh Style="text-align:right">Fee</MudTh>
-        <MudTh>Verified At (UTC)</MudTh>
-    </HeaderContent>
-    <RowTemplate>
-        <MudTd DataLabel="Transaction Id">@LinkHelper.GetObjectLink(context)</MudTd>
-        <MudTd DataLabel="Type">@context.typeName</MudTd>
-        <TransactionTableDetails TransactionData=@context />
-        <MudTd DataLabel="Timestamp">@context.verifiedAt</MudTd>
-    </RowTemplate>
-</MudTable>
-<br />
-<MudTable Dense="true" Striped="true" Bordered="true" Items="@holders" Hover="true" Loading=@isLoadingHolders>
-    <ToolBarContent>
-        <MudText Typo="Typo.h6">NFT Holders</MudText>
-        <MudSpacer />
-        <MudIconButton Icon="@Icons.Filled.FirstPage" Disabled=@(goToHolderPage == 1) OnClick="@(() => goToHolderPage = 1)" />
-        <MudIconButton Icon="@Icons.Filled.NavigateBefore" Disabled=@(goToHolderPage == 1) OnClick="@(() => goToHolderPage -= 1)" />
-        <MudNumericField HideSpinButtons="true" @bind-Value="goToHolderPage" Label="Page" Variant="Variant.Outlined" Min="1" Margin="Margin.Dense" Class="flex-grow-0" Style="width:50px;" />
-        <MudIconButton Icon="@Icons.Filled.NavigateNext" Disabled=@(holders!.Count < pageSize) OnClick="@(() => goToHolderPage += 1)" />
-        <MudSpacer />
-    </ToolBarContent>
-    <HeaderContent>
-        <MudTh>Account Id</MudTh>
-        <MudTh>Address</MudTh>
-        <MudTh>Balance</MudTh>
-    </HeaderContent>
-    <RowTemplate>
-        <MudTd DataLabel="Account Id">@context?.account?.id</MudTd>
-        <MudTd DataLabel="Address">@LinkHelper.CreateUserLink(context?.account?.id, context?.account?.address, true)</MudTd>
-        <MudTd DataLabel="Timestamp">@context?.balance</MudTd>
-    </RowTemplate>
-</MudTable>
-
+<MudExpansionPanels MultiExpansion="true">
+    <MudExpansionPanel Text="Transactions" DisableGutters="true" @bind-IsExpanded="txIsOpen" HideIcon="true">
+            <TitleContent>
+                <div class="d-flex">
+                    <MudIcon Icon="@(txIsOpen ? Icons.Material.Filled.KeyboardArrowUp : Icons.Material.Filled.KeyboardArrowDown)" class="mr-3"></MudIcon>
+                    <MudText>Transactions</MudText>
+                </div>
+            </TitleContent>
+            <ChildContent>
+                <MudTable Dense="true" Striped="true" Bordered="true" Items="@transactions" Hover="true" Loading=@isLoading>
+                    <ToolBarContent>
+                        <MudIconButton Icon="@Icons.Filled.FirstPage" Disabled=@(gotoPage == 1) OnClick="@(() => gotoPage = 1)" />
+                        <MudIconButton Icon="@Icons.Filled.NavigateBefore" Disabled=@(gotoPage == 1) OnClick="@(() => gotoPage -= 1)" />
+                        <MudNumericField HideSpinButtons="true" @bind-Value="gotoPage" Label="Page" Variant="Variant.Outlined" Min="1" Margin="Margin.Dense" Class="flex-grow-0" Style="width:50px;" />
+                        <MudIconButton Icon="@Icons.Filled.NavigateNext" Disabled=@(transactions!.Count < pageSize) OnClick="@(() => gotoPage += 1)" />
+                        <MudSpacer />
+                    </ToolBarContent>
+                    <HeaderContent>
+                        <MudTh>Tx Id</MudTh>
+                        <MudTh>Type</MudTh>
+                        <MudTh>From</MudTh>
+                        <MudTh>To</MudTh>
+                        <MudTh Style="text-align:right">Bought</MudTh>
+                        <MudTh Style="text-align:right">Sold</MudTh>
+                        <MudTh Style="text-align:right">Fee</MudTh>
+                        <MudTh>Verified At (UTC)</MudTh>
+                    </HeaderContent>
+                    <RowTemplate>
+                        <MudTd DataLabel="Transaction Id">@LinkHelper.GetObjectLink(context)</MudTd>
+                        <MudTd DataLabel="Type">@context.typeName</MudTd>
+                        <TransactionTableDetails TransactionData=@context />
+                        <MudTd DataLabel="Timestamp">@context.verifiedAt</MudTd>
+                    </RowTemplate>
+                </MudTable>
+            </ChildContent>
+    </MudExpansionPanel>
+    <MudExpansionPanel Text="Holders" DisableGutters="true" @bind-IsExpanded="holdersIsOpen" HideIcon="true">
+            <TitleContent>
+                <div class="d-flex">
+                    <MudIcon Icon="@(holdersIsOpen ? Icons.Material.Filled.KeyboardArrowUp : Icons.Material.Filled.KeyboardArrowDown)" class="mr-3"></MudIcon>
+                    <MudText>NFT Holders</MudText>
+                </div>
+            </TitleContent>
+            <ChildContent>
+                <MudTable Dense="true" Striped="true" Bordered="true" Items="@holders" Hover="true" Loading=@isLoadingHolders>
+                    <ToolBarContent>
+                        <MudIconButton Icon="@Icons.Filled.FirstPage" Disabled=@(goToHolderPage == 1) OnClick="@(() => goToHolderPage = 1)" />
+                        <MudIconButton Icon="@Icons.Filled.NavigateBefore" Disabled=@(goToHolderPage == 1) OnClick="@(() => goToHolderPage -= 1)" />
+                        <MudNumericField HideSpinButtons="true" @bind-Value="goToHolderPage" Label="Page" Variant="Variant.Outlined" Min="1" Margin="Margin.Dense" Class="flex-grow-0" Style="width:50px;" />
+                        <MudIconButton Icon="@Icons.Filled.NavigateNext" Disabled=@(holders!.Count < pageSize) OnClick="@(() => goToHolderPage += 1)" />
+                        <MudSpacer />
+                    </ToolBarContent>
+                    <HeaderContent>
+                        <MudTh>Account Id</MudTh>
+                        <MudTh>Address</MudTh>
+                        <MudTh>Balance</MudTh>
+                    </HeaderContent>
+                    <RowTemplate>
+                        <MudTd DataLabel="Account Id">@context?.account?.id</MudTd>
+                        <MudTd DataLabel="Address">@LinkHelper.CreateUserLink(context?.account?.id, context?.account?.address, true)</MudTd>
+                        <MudTd DataLabel="Balance">@context?.balance</MudTd>
+                    </RowTemplate>
+                </MudTable>
+            </ChildContent>
+    </MudExpansionPanel>
+</MudExpansionPanels>
 
 @code {
     [Parameter]
@@ -174,7 +189,8 @@
     public bool isLoading = true;
     public bool isLoadingHolders = true;
     public readonly int pageSize = 25;
-
+    bool txIsOpen;
+    bool holdersIsOpen;
     private NftMetadata? nftMetadata;
 
     public int gotoPage

--- a/Lexplorer/Pages/NFTDetail.razor
+++ b/Lexplorer/Pages/NFTDetail.razor
@@ -109,6 +109,7 @@
             <ChildContent>
                 <MudTable Dense="true" Striped="true" Bordered="true" Items="@transactions" Hover="true" Loading=@isLoading>
                     <ToolBarContent>
+                        <MudSpacer />
                         <MudIconButton Icon="@Icons.Filled.FirstPage" Disabled=@(gotoPage == 1) OnClick="@(() => gotoPage = 1)" />
                         <MudIconButton Icon="@Icons.Filled.NavigateBefore" Disabled=@(gotoPage == 1) OnClick="@(() => gotoPage -= 1)" />
                         <MudNumericField HideSpinButtons="true" @bind-Value="gotoPage" Label="Page" Variant="Variant.Outlined" Min="1" Margin="Margin.Dense" Class="flex-grow-0" Style="width:50px;" />
@@ -138,6 +139,7 @@
             <ChildContent>
                 <MudTable Dense="true" Striped="true" Bordered="true" Items="@holders" Hover="true" Loading=@isLoadingHolders>
                     <ToolBarContent>
+                        <MudSpacer />
                         <MudIconButton Icon="@Icons.Filled.FirstPage" Disabled=@(goToHolderPage == 1) OnClick="@(() => goToHolderPage = 1)" />
                         <MudIconButton Icon="@Icons.Filled.NavigateBefore" Disabled=@(goToHolderPage == 1) OnClick="@(() => goToHolderPage -= 1)" />
                         <MudNumericField HideSpinButtons="true" @bind-Value="goToHolderPage" Label="Page" Variant="Variant.Outlined" Min="1" Margin="Margin.Dense" Class="flex-grow-0" Style="width:50px;" />

--- a/Lexplorer/Pages/NFTDetail.razor
+++ b/Lexplorer/Pages/NFTDetail.razor
@@ -105,13 +105,7 @@
 
 <br />
 <MudExpansionPanels MultiExpansion="true">
-    <MudExpansionPanel Text="Transactions" DisableGutters="true" @bind-IsExpanded="txIsOpen" HideIcon="true">
-            <TitleContent>
-                <div class="d-flex">
-                    <MudIcon Icon="@(txIsOpen ? Icons.Material.Filled.KeyboardArrowUp : Icons.Material.Filled.KeyboardArrowDown)" class="mr-3"></MudIcon>
-                    <MudText>Transactions</MudText>
-                </div>
-            </TitleContent>
+    <LexpansionPanel Text="Transactions">
             <ChildContent>
                 <MudTable Dense="true" Striped="true" Bordered="true" Items="@transactions" Hover="true" Loading=@isLoading>
                     <ToolBarContent>
@@ -139,14 +133,8 @@
                     </RowTemplate>
                 </MudTable>
             </ChildContent>
-    </MudExpansionPanel>
-    <MudExpansionPanel Text="Holders" DisableGutters="true" @bind-IsExpanded="holdersIsOpen" HideIcon="true">
-            <TitleContent>
-                <div class="d-flex">
-                    <MudIcon Icon="@(holdersIsOpen ? Icons.Material.Filled.KeyboardArrowUp : Icons.Material.Filled.KeyboardArrowDown)" class="mr-3"></MudIcon>
-                    <MudText>NFT Holders</MudText>
-                </div>
-            </TitleContent>
+    </LexpansionPanel>
+    <LexpansionPanel Text="Holders">
             <ChildContent>
                 <MudTable Dense="true" Striped="true" Bordered="true" Items="@holders" Hover="true" Loading=@isLoadingHolders>
                     <ToolBarContent>
@@ -168,7 +156,7 @@
                     </RowTemplate>
                 </MudTable>
             </ChildContent>
-    </MudExpansionPanel>
+    </LexpansionPanel>
 </MudExpansionPanels>
 
 @code {
@@ -189,8 +177,6 @@
     public bool isLoading = true;
     public bool isLoadingHolders = true;
     public readonly int pageSize = 25;
-    bool txIsOpen;
-    bool holdersIsOpen;
     private NftMetadata? nftMetadata;
 
     public int gotoPage

--- a/Lexplorer/Pages/NFTDetail.razor
+++ b/Lexplorer/Pages/NFTDetail.razor
@@ -63,7 +63,7 @@
             <tr>
                 <td colspan="2">
                     <MudExpansionPanels>
-                        <MudExpansionPanel Text="Traits">
+                        <LexpansionPanel Text="Traits">
                             <MudSimpleTable Dense="true" Striped="true" Bordered="true">
                                 <tbody>
                                     @foreach (var trait in nftMetadata?.attributes!)
@@ -75,7 +75,7 @@
                                     }
                                 </tbody>
                             </MudSimpleTable>
-                        </MudExpansionPanel>
+                        </LexpansionPanel>
                     </MudExpansionPanels>
                 </td>
             </tr>


### PR DESCRIPTION
Closes #202 

## Features:
* Changed from Tabs to Expansion Panels in AccountsDetail and NFTDetails pages
* Small update to NFTGrid pagination so it better fits the panels