### PR TITLE
Fix #209 Cancellation token disposed errors

### DIFF
--- a/Lexplorer/Components/NFTGrid.razor
+++ b/Lexplorer/Components/NFTGrid.razor
@@ -86,7 +86,8 @@
     private Dictionary<string, NftMetadata> NFTdata { get; set; } = new Dictionary<string, NftMetadata>();
     private CancellationTokenSource? cts = null;
 
-    public async Task<NftMetadata?> LoadNFTMetaData(AccountNFTSlot? slot, CancellationToken cancellationToken = default)
+    public static async Task<NftMetadata?> LoadNFTMetaData(AccountNFTSlot? slot, EthereumService EthereumService,
+        NftMetadataService NftMetadataService, IAppCache AppCache, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrEmpty(slot?.nft?.nftID)) return null;
 
@@ -110,7 +111,7 @@
     {
         foreach (var slot in NFTSlots!)
         {
-            var nftMetadata = await LoadNFTMetaData(slot, cancellationToken);
+            var nftMetadata = await LoadNFTMetaData(slot, EthereumService, NftMetadataService, AppCache, cancellationToken);
             if (nftMetadata == null) continue;
 
             NFTdata.Add(slot!.nft!.nftID!, nftMetadata);
@@ -146,7 +147,7 @@
                     Trace.WriteLine(e.StackTrace + "\n" + e.Message);
                 }
                 finally
-                { 
+                {
                     //now for cleanup, we must clear cts, but only if it is still our localCTS, which we're about to dispose
                     //otherwise a new call has already replaced cts with it's own localCTS
                     Interlocked.CompareExchange<CancellationTokenSource?>(ref cts, null, localCTS);

--- a/Lexplorer/Components/NFTGrid.razor
+++ b/Lexplorer/Components/NFTGrid.razor
@@ -132,7 +132,7 @@
             {
                 //give future calls a chance to cancel us; it is now safe to replace
                 //any previous value of cts, since we already cancelled it above
-                cts = localCTS;
+                Interlocked.Exchange<CancellationTokenSource?>(ref cts, localCTS);
                 try
                 {
                     NFTdata = new Dictionary<string, NftMetadata>();
@@ -145,9 +145,12 @@
                 {
                     Trace.WriteLine(e.StackTrace + "\n" + e.Message);
                 }
-                //now for cleanup, we must clear cts, but only if it is still our localCTS, which we're about to dispose
-                //otherwise a new call has already replaced cts with it's own localCTS
-                Interlocked.CompareExchange<CancellationTokenSource?>(ref cts, null, localCTS);
+                finally
+                { 
+                    //now for cleanup, we must clear cts, but only if it is still our localCTS, which we're about to dispose
+                    //otherwise a new call has already replaced cts with it's own localCTS
+                    Interlocked.CompareExchange<CancellationTokenSource?>(ref cts, null, localCTS);
+                }
             }
         }
     }

--- a/Lexplorer/Components/NFTGrid.razor
+++ b/Lexplorer/Components/NFTGrid.razor
@@ -154,9 +154,10 @@
 
     public void Dispose()
     {
+        //just cancel any OnParametersSetAsync that might be running
+        //do not dispose cts here, it's just a copy of localCTS whose
+        //lifetime is managed within OnParametersSetAsync
         cts?.Cancel();
-        cts?.Dispose();
-        cts = null;
     }
 
     private NftMetadata? GetMetadata(string? nftID)

--- a/Lexplorer/Pages/AccountDetails.razor
+++ b/Lexplorer/Pages/AccountDetails.razor
@@ -180,7 +180,7 @@
         {
             //give future calls a chance to cancel us; it is now safe to replace
             //any previous value of cts, since we already cancelled it above
-            cts = localCTS;
+            Interlocked.Exchange<CancellationTokenSource?>(ref cts, localCTS);
             try
             {
                 isLoading = true;
@@ -258,9 +258,12 @@
             {
                 Trace.WriteLine(e.StackTrace + "\n" + e.Message);
             }
-            //now for cleanup, we must clear cts, but only if it is still our localCTS, which we're about to dispose
-            //otherwise a new call has already replaced cts with it's own localCTS
-            Interlocked.CompareExchange<CancellationTokenSource?>(ref cts, null, localCTS);
+            finally
+            { 
+                //now for cleanup, we must clear cts, but only if it is still our localCTS, which we're about to dispose
+                //otherwise a new call has already replaced cts with it's own localCTS
+                Interlocked.CompareExchange<CancellationTokenSource?>(ref cts, null, localCTS);
+            }
         }
     }
 

--- a/Lexplorer/Pages/AccountsOverview.razor
+++ b/Lexplorer/Pages/AccountsOverview.razor
@@ -96,8 +96,7 @@
         {
             //give future calls a chance to cancel us; it is now safe to replace
             //any previous value of cts, since we already cancelled it above
-            cts = localCTS;
-
+            Interlocked.Exchange<CancellationTokenSource?>(ref cts, localCTS);
             try
             {
                 isLoading = true;
@@ -116,9 +115,12 @@
             {
                 Trace.WriteLine(e.StackTrace + "\n" + e.Message);
             }
-            //now for cleanup, we must clear cts, but only if it is still our localCTS, which we're about to dispose
-            //otherwise a new call has already replaced cts with it's own localCTS
-            Interlocked.CompareExchange<CancellationTokenSource?>(ref cts, null, localCTS);
+            finally
+            { 
+                //now for cleanup, we must clear cts, but only if it is still our localCTS, which we're about to dispose
+                //otherwise a new call has already replaced cts with it's own localCTS
+                Interlocked.CompareExchange<CancellationTokenSource?>(ref cts, null, localCTS);
+            }
         }
     }
 

--- a/Lexplorer/Pages/BlockDetails.razor
+++ b/Lexplorer/Pages/BlockDetails.razor
@@ -137,11 +137,9 @@
         {
             //give future calls a chance to cancel us; it is now safe to replace
             //any previous value of cts, since we already cancelled it above
+            Interlocked.Exchange<CancellationTokenSource?>(ref cts, localCTS);
             try
             {
-
-                cts = localCTS;
-
                 isBlockLoading = true;
                 string blockCacheKey = $"blockDetailOverview-{blockId}";
                 block = await AppCache.GetOrAddAsyncNonNull(blockCacheKey,
@@ -168,9 +166,12 @@
             {
                 Trace.WriteLine(e.StackTrace + "\n" + e.Message);
             }
-            //now for cleanup, we must clear cts, but only if it is still our localCTS, which we're about to dispose
-            //otherwise a new call has already replaced cts with it's own localCTS
-            Interlocked.CompareExchange<CancellationTokenSource?>(ref cts, null, localCTS);
+            finally
+            { 
+                //now for cleanup, we must clear cts, but only if it is still our localCTS, which we're about to dispose
+                //otherwise a new call has already replaced cts with it's own localCTS
+                Interlocked.CompareExchange<CancellationTokenSource?>(ref cts, null, localCTS);
+            }
         }
     }
 }

--- a/Lexplorer/Pages/NFTCollection.razor
+++ b/Lexplorer/Pages/NFTCollection.razor
@@ -65,12 +65,10 @@
     <br />
 
     <br />
-    <NFTGrid @ref="nftGrid" @bind-PageNumber="@goToPage" NFTSlots="@collectionNFTSlots" PageCount="@maxPageCount" />
+    <NFTGrid @bind-PageNumber="@goToPage" NFTSlots="@collectionNFTSlots" PageCount="@maxPageCount" />
 </MudContainer>
 
 @code {
-    private NFTGrid nftGrid = default!;
-
     [Parameter]
     public string? tokenAddress { get; set; }
 
@@ -128,7 +126,7 @@
                     Select(NFT => new AccountNFTSlot() { nft = NFT }).ToList();
                 StateHasChanged();
 
-                var metaData = await nftGrid.LoadNFTMetaData(collectionNFTSlots!.FirstOrDefault());
+                var metaData = await NFTGrid.LoadNFTMetaData(collectionNFTSlots!.FirstOrDefault(), EthereumService, NftMetadataService, AppCache, localCTS.Token);
                 if (string.IsNullOrEmpty(metaData?.collection_metadata)) return;
 
                 string collectionMetaDataKey = $"collectionMetadata-{tokenAddress}";

--- a/Lexplorer/Pages/NFTCollection.razor
+++ b/Lexplorer/Pages/NFTCollection.razor
@@ -95,7 +95,7 @@
 
     public int maxPageCount { get; set; } = 1;
 
-    private CancellationTokenSource? cts;
+    private CancellationTokenSource? cts = null;
     private IList<AccountNFTSlot>? collectionNFTSlots { get; set; }
     private NftCollectionMetadata? collectionMetadata { get; set; }
 
@@ -109,11 +109,11 @@
 
         using (CancellationTokenSource localCTS = new CancellationTokenSource())
         {
-            //give future calls a chance to cancel us; it is now safe to replace
-            //any previous value of cts, since we already cancelled it above
-            cts = localCTS;
             try
             {
+                //give future calls a chance to cancel us; it is now safe to replace
+                //any previous value of cts, since we already cancelled it above
+                Interlocked.Exchange<CancellationTokenSource?>(ref cts, localCTS);
                 if (string.IsNullOrEmpty(tokenAddress)) return;
 
                 string collectionNftKey = $"collection-{tokenAddress}-page-{goToPage}";
@@ -145,9 +145,12 @@
             {
                 Trace.WriteLine(e.StackTrace + "\n" + e.Message);
             }
-            //now for cleanup, we must clear cts, but only if it is still our localCTS, which we're about to dispose
-            //otherwise a new call has already replaced cts with it's own localCTS
-            Interlocked.CompareExchange<CancellationTokenSource?>(ref cts, null, localCTS);
+            finally
+            {
+                //now for cleanup, we must clear cts, but only if it is still our localCTS, which we're about to dispose
+                //otherwise a new call has already replaced cts with it's own localCTS
+                Interlocked.CompareExchange<CancellationTokenSource?>(ref cts, null, localCTS);
+            }
         }
     }
 

--- a/Lexplorer/Pages/NFTDetail.razor
+++ b/Lexplorer/Pages/NFTDetail.razor
@@ -237,7 +237,7 @@
         {
             //give future calls a chance to cancel us; it is now safe to replace
             //any previous value of cts, since we already cancelled it above
-            cts = localCTS;
+            Interlocked.Exchange<CancellationTokenSource?>(ref cts, localCTS);
             try
             {
                 isLoading = true;
@@ -280,7 +280,7 @@
                     DateTimeOffset.UtcNow.AddMinutes(10));
                 isLoadingHolders = false;
                 StateHasChanged();
-                
+
 
                 //load the NFT metadata last - it might actually take the longest and other services are queried etc.
                 if (nftMetadata == null)
@@ -310,9 +310,12 @@
             {
                 Trace.WriteLine(e.StackTrace + "\n" + e.Message);
             }
-            //now for cleanup, we must clear cts, but only if it is still our localCTS, which we're about to dispose
-            //otherwise a new call has already replaced cts with it's own localCTS
-            Interlocked.CompareExchange<CancellationTokenSource?>(ref cts, null, localCTS);
+            finally
+            {
+                //now for cleanup, we must clear cts, but only if it is still our localCTS, which we're about to dispose
+                //otherwise a new call has already replaced cts with it's own localCTS
+                Interlocked.CompareExchange<CancellationTokenSource?>(ref cts, null, localCTS);
+            }
         }
     }
 


### PR DESCRIPTION
As reported in #209

* added finally block to all relevant places so cts will always be reset to null
* in NFTGrid no longer dispose the cts - as it's not owned by the grid itself
* use Interlock.Exchange when initially setting cts too, just for consistency
* fixed catches null exception when nftGrid reference was not yet set by making it's method static and passing in all relevant services