### PR TITLE
Fix #210 alternative properties syntax

### DIFF
--- a/Shared/Models/NftMetadata.cs
+++ b/Shared/Models/NftMetadata.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Newtonsoft.Json;
 
 namespace Lexplorer.Models
 {
     public class NftMetadata
     {
-        public string? description { get; set;}
+        public string? description { get; set; }
         public string? image { get; set; }
         public string? name { get; set; }
         public int royalty_percentage { get; set; }
@@ -17,6 +18,8 @@ namespace Lexplorer.Models
         public string? collection_metadata { get; set; }
 
         public List<NftAttribute>? attributes { get; set; }
+
+        [JsonIgnore] //we read this manually to be fail-safe
         public Dictionary<string, object>? properties { get; set; }
 
         public string? JSONContent { get; set; }

--- a/Shared/Services/NftMetadataService.cs
+++ b/Shared/Services/NftMetadataService.cs
@@ -88,6 +88,22 @@ namespace Lexplorer.Services
                     {
                         if (propToken is JObject)
                             metadata.properties = propToken.ToObject<Dictionary<string, object>>();
+                        else if (propToken is JArray jarr)
+                        {
+                            metadata.properties = new();
+                            foreach (var arrToken in jarr)
+                            {
+                                try
+                                {
+                                    if (arrToken is JObject obj)
+                                        metadata.properties.Add(obj["key"]!.ToString(), obj["value"]!.ToObject<object>()!);
+                                }
+                                catch
+                                {
+
+                                }
+                            }
+                        }
                     }
                     catch (Exception e)
                     {

--- a/Shared/Services/NftMetadataService.cs
+++ b/Shared/Services/NftMetadataService.cs
@@ -74,6 +74,35 @@ namespace Lexplorer.Services
             return nmd;
         }
 
+        public NftMetadata? GetMetadataFromResponse(string response)
+        {
+            try
+            { 
+                var token = JToken.Parse(response!);
+                var metadata = token.ToObject<NftMetadata>();
+                if ((token != null) && (metadata != null))
+                {
+                    metadata.JSONContent = token.ToString(Formatting.Indented);
+                    var propToken = token["properties"];
+                    try
+                    {
+                        if (propToken is JObject)
+                            metadata.properties = propToken.ToObject<Dictionary<string, object>>();
+                    }
+                    catch (Exception e)
+                    {
+                        Trace.WriteLine(e.StackTrace + "\n" + e.Message);
+                    }
+                }
+                return metadata;
+            }
+            catch (Exception e)
+            {
+                Trace.WriteLine(e.StackTrace + "\n" + e.Message);
+                return null;
+            }
+        }
+
         private async Task<NftMetadata?> GetMetadataFromURL(string URL, CancellationToken cancellationToken = default)
         {
             var request = new RestRequest(URL);
@@ -81,16 +110,7 @@ namespace Lexplorer.Services
             {
                 request.Timeout = 10000; //we can't afford to wait forever here, 10s must be enough
                 var response = await _client.GetAsync(request, cancellationToken);
-                var token = JToken.Parse(response.Content!);
-                var metadata = token.ToObject<NftMetadata>();
-                if ((token != null) && (metadata != null))
-                {
-                    metadata.JSONContent = token.ToString(Formatting.Indented);
-                    var propToken = token["properties"];
-                    if (propToken != null)
-                        metadata.properties = propToken.ToObject<Dictionary<string, object>>();
-                }
-                return metadata;
+                return GetMetadataFromResponse(response.Content!);
             }
             catch (Exception e)
             {

--- a/xUnitTests/NFTMetaDataTests/TestNFTMetaData.cs
+++ b/xUnitTests/NFTMetaDataTests/TestNFTMetaData.cs
@@ -101,6 +101,26 @@ namespace xUnitTests.NFTMetaDataTests
 			var contentType = await fixture.NMS.GetContentTypeFromURL(meta!.animation_url!);
 			Assert.Equal("text/html", contentType);
 		}
-	}
+
+        [Fact]
+		public void TestCorrectJSONPropertiesDictionary()
+        {
+			var meta = fixture.NMS.GetMetadataFromResponse(
+				"{\"name\":\"Test\",\"properties\":{\"test\": \"value\"}}");
+			Assert.NotNull(meta);
+			Assert.Equal("Test", meta!.name);
+			Assert.Equal("value", meta!.properties!["test"]);
+        }
+
+        [Fact]
+        public void TestCorrectJSONPropertiesKeyValuArray()
+        {
+            var meta = fixture.NMS.GetMetadataFromResponse(
+                "{\"name\":\"Test\",\"properties\":[{\"key\": \"test\", \"value\": \"value\"}]}");
+            Assert.NotNull(meta);
+            Assert.Equal("Test", meta!.name);
+			Assert.Null(meta!.properties);
+        }
+    }
 }
 

--- a/xUnitTests/NFTMetaDataTests/TestNFTMetaData.cs
+++ b/xUnitTests/NFTMetaDataTests/TestNFTMetaData.cs
@@ -116,10 +116,10 @@ namespace xUnitTests.NFTMetaDataTests
         public void TestCorrectJSONPropertiesKeyValuArray()
         {
             var meta = fixture.NMS.GetMetadataFromResponse(
-                "{\"name\":\"Test\",\"properties\":[{\"key\": \"test\", \"value\": \"value\"}]}");
+                "{\"name\":\"Test\",\"properties\":[{\"key\": \"test\", \"value\": \"value\"}, {\"invalid\": \"value\"}]}");
             Assert.NotNull(meta);
             Assert.Equal("Test", meta!.name);
-			Assert.Null(meta!.properties);
+            Assert.Equal("value", meta!.properties!["test"]);
         }
     }
 }


### PR DESCRIPTION
Fixes #210 

array syntax: `0x32f006a901505c8c015714cc4390f7f5447c1b07983b050c9cd92da90777584c`
dictionary syntax: `0x4af1532239111dd9ff37a69b0241581252a5728eb6a9b78095655413f3861e66`

* properties is now `JsonIgnore` and manually deserialised in a fail-safe way
* the alternative syntax (array of objects with "key" and "value" properties) is manually parsed
* refactored deserialisation and added tests for both variants