### PR TITLE
#119 New open ended pager component

### DIFF
--- a/Lexplorer/Components/OpenEndedPager.razor
+++ b/Lexplorer/Components/OpenEndedPager.razor
@@ -1,0 +1,55 @@
+﻿@if (IsOptionalBottomPager)
+{
+    <MudHidden Breakpoint="Breakpoint.MdAndDown" Invert="true">
+        <MudPaper Width="100%">
+            <MudToolBar Class="justify-center">
+                <MudIconButton Icon="@Icons.Filled.FirstPage" Disabled=@(internalPageNumber == 1) OnClick="@(() => internalPageNumber = 1)" />
+                <MudIconButton Icon="@Icons.Filled.NavigateBefore" Disabled=@(internalPageNumber == 1) OnClick="@(() => internalPageNumber -= 1)" />
+                <MudNumericField HideSpinButtons="true" @bind-Value="internalPageNumber" Label="Page" Variant="Variant.Outlined" Min="1" Margin="Margin.Dense" Class="flex-grow-0" Style="width:50px;" />
+                <MudIconButton Icon="@Icons.Filled.NavigateNext" Disabled=@IsLastPage OnClick="@(() => internalPageNumber += 1)" />
+            </MudToolBar>
+        </MudPaper>
+    </MudHidden>
+}
+else
+{
+    <MudIconButton Icon="@Icons.Filled.FirstPage" Disabled=@(internalPageNumber == 1) OnClick="@(() => internalPageNumber = 1)" />
+    <MudIconButton Icon="@Icons.Filled.NavigateBefore" Disabled=@(internalPageNumber == 1) OnClick="@(() => internalPageNumber -= 1)" />
+    <MudNumericField HideSpinButtons="true" @bind-Value="internalPageNumber" Label="Page" Variant="Variant.Outlined" Min="1" Margin="Margin.Dense" Class="flex-grow-0" Style="width:50px;" />
+    <MudIconButton Icon="@Icons.Filled.NavigateNext" Disabled=@IsLastPage OnClick="@(() => internalPageNumber += 1)" />
+}
+
+@code {
+    [Parameter]
+    public bool IsOptionalBottomPager { get; set; } = false;
+
+    private int _internalPageNumber = 1;
+    private int internalPageNumber {
+        get
+        {
+            return _internalPageNumber;
+        }
+        set
+        {
+            _internalPageNumber = value;
+            if (PageNumber != _internalPageNumber)
+                PageNumberChanged.InvokeAsync(_internalPageNumber);
+        }
+    }
+
+    [Parameter]
+    public int PageNumber { get; set; }
+
+    [Parameter]
+    public EventCallback<int> PageNumberChanged { get; set; }
+
+    [Parameter]
+    public bool IsLastPage { get; set; }
+
+    protected override void OnParametersSet()
+    {
+        base.OnParametersSet();
+        _internalPageNumber = PageNumber;
+    }
+
+}

--- a/Lexplorer/Pages/AccountDetails.razor
+++ b/Lexplorer/Pages/AccountDetails.razor
@@ -87,10 +87,7 @@
                         <MudText Typo="Typo.h6" Class="d-none d-sm-flex">Transactions</MudText>
                         <MudText Typo="Typo.h6" Class="d-flex d-sm-none d-xs-none">Tx's</MudText>
                         <MudSpacer />
-                        <MudIconButton Icon="@Icons.Filled.FirstPage" Disabled=@(gotoPage == 1) OnClick="@(() => gotoPage = 1)" />
-                        <MudIconButton Icon="@Icons.Filled.NavigateBefore" Disabled=@(gotoPage == 1) OnClick="@(() => gotoPage -= 1)" />
-                        <MudNumericField HideSpinButtons="true" @bind-Value="gotoPage" Label="Page" Variant="Variant.Outlined" Min="1" Margin="Margin.Dense" Class="flex-grow-0" Style="width:50px;" />
-                        <MudIconButton Icon="@Icons.Filled.NavigateNext" Disabled=@(transactions!.Count < pageSize) OnClick="@(() => gotoPage += 1)" />
+                        <OpenEndedPager @bind-PageNumber="gotoPage" IsLastPage="@(transactions!.Count < pageSize)" />
                         <MudSpacer />
                         <MudIconButton Icon="@Icons.Filled.Download" OnClick="ShowCSVOptions" />
                     </ToolBarContent>
@@ -111,6 +108,7 @@
                         <MudTd DataLabel="Timestamp">@context.verifiedAt</MudTd>
                     </RowTemplate>
                 </MudTable>
+                <OpenEndedPager @bind-PageNumber="gotoPage" IsLastPage="@(transactions!.Count < pageSize)" IsOptionalBottomPager="true" />
             </ChildContent>
         </LexpansionPanel>
     </MudExpansionPanels>
@@ -135,7 +133,8 @@
         }
         set
         {
-            string URL = $"/account/{accountId}?pageNumber={value}&nftPageNumber={nftPageNumber}";
+            pageNumber = value.ToString();
+            var URL = NavigationManager.GetUriWithQueryParameter(nameof(pageNumber), pageNumber);
             NavigationManager.NavigateTo(URL);
         }
     }

--- a/Lexplorer/Pages/AccountsOverview.razor
+++ b/Lexplorer/Pages/AccountsOverview.razor
@@ -10,10 +10,7 @@
     <ToolBarContent>
         <MudText Typo="Typo.h6">Latest accounts</MudText>
         <MudSpacer />
-        <MudIconButton Icon="@Icons.Filled.FirstPage" Disabled=@(gotoPage == 1) OnClick="@(() => gotoPage = 1)" />
-        <MudIconButton Icon="@Icons.Filled.NavigateBefore" Disabled=@(gotoPage == 1) OnClick="@(() => gotoPage -= 1)" />
-        <MudNumericField HideSpinButtons="true" @bind-Value="gotoPage" Label="Page" Variant="Variant.Outlined" Min="1" Margin="Margin.Dense" Class="flex-grow-0" Style="width:50px;" />
-        <MudIconButton Icon="@Icons.Filled.NavigateNext" Disabled=@(accounts!.Count < pageSize) OnClick="@(() => gotoPage += 1)" />
+        <OpenEndedPager @bind-PageNumber="@gotoPage" IsLastPage="@(accounts!.Count < pageSize)" />
         <MudSpacer />
         <MudSelect @bind-Value="@filterAccounts" T="string" Label="Filter by type">
             <MudSelectItem Value="@("All")" />
@@ -35,6 +32,7 @@
         <MudTd DataLabel="CreatedAt">@context.createdAtTransaction?.verifiedAt</MudTd>
     </RowTemplate>
 </MudTable>
+<OpenEndedPager @bind-PageNumber="@gotoPage" IsLastPage="@(accounts!.Count < pageSize)" IsOptionalBottomPager="true" />
 
 
 @code {
@@ -50,7 +48,9 @@
         }
         set
         {
-            navigateTo(value);
+            pageNumber = value.ToString();
+            var URL = NavigationManager.GetUriWithQueryParameter(nameof(pageNumber), pageNumber);
+            NavigationManager.NavigateTo(URL);
         }
     }
 
@@ -72,16 +72,9 @@
         set
         {
             type = (string.Equals(value ?? "All", "All", StringComparison.InvariantCultureIgnoreCase)) ? null : value;
-            navigateTo(gotoPage);
+            var URL = NavigationManager.GetUriWithQueryParameter(nameof(type), type);
+            NavigationManager.NavigateTo(URL);
         }
-    }
-
-    private void navigateTo(int page)
-    {
-        string URL = $"/account?pageNumber={page}";
-        if (type != null)
-            URL += $"&type={type}";
-        NavigationManager.NavigateTo(URL);
     }
 
     private CancellationTokenSource? cts;

--- a/Lexplorer/Pages/BlockDetails.razor
+++ b/Lexplorer/Pages/BlockDetails.razor
@@ -137,6 +137,7 @@
             Interlocked.Exchange<CancellationTokenSource?>(ref cts, localCTS);
             try
             {
+                transactions = new List<Transaction>();
                 isBlockLoading = true;
                 string blockCacheKey = $"blockDetailOverview-{blockId}";
                 block = await AppCache.GetOrAddAsyncNonNull(blockCacheKey,
@@ -144,9 +145,9 @@
                     DateTimeOffset.UtcNow.AddMinutes(5));
                 if (block == null) return;
                 isBlockLoading = false;
+                isTransactionLoading = true;
                 StateHasChanged();
 
-                isTransactionLoading = true;
                 string transactionDatacacheKey = $"blockDetailTransactions-{blockId}-page{gotoPage}";
                 var transactionData = await AppCache.GetOrAddAsyncNonNull(transactionDatacacheKey,
                     async () => await LoopringGraphQLService.GetTransactions((gotoPage - 1) * pageSize, pageSize, blockId: blockNumber, cancellationToken: localCTS.Token),

--- a/Lexplorer/Pages/BlockDetails.razor
+++ b/Lexplorer/Pages/BlockDetails.razor
@@ -58,10 +58,7 @@
     <ToolBarContent>
         <MudText Typo="Typo.h6">Transactions in block #@block?.data?.block?.id</MudText>
         <MudSpacer />
-        <MudIconButton Icon="@Icons.Filled.FirstPage" Disabled=@(gotoPage == 1) OnClick="@(() => gotoPage = 1)" />
-        <MudIconButton Icon="@Icons.Filled.NavigateBefore" Disabled=@(gotoPage == 1) OnClick="@(() => gotoPage -= 1)" />
-        <MudNumericField HideSpinButtons="true" @bind-Value="gotoPage" Label="Page" Variant="Variant.Outlined" Min="1" Margin="Margin.Dense" Class="flex-grow-0" Style="width:50px;" />
-        <MudIconButton Icon="@Icons.Filled.NavigateNext" Disabled=@(transactions?.Count < pageSize) OnClick="@(() => gotoPage += 1)" />
+        <OpenEndedPager @bind-PageNumber="@gotoPage" IsLastPage="@(transactions?.Count < pageSize)" />
         <MudSpacer />
     </ToolBarContent>
     <HeaderContent>
@@ -81,6 +78,7 @@
         <MudTd DataLabel="Time">@TimestampConverter.ToUTCString(@block?.data?.block?.timestamp)</MudTd>
     </RowTemplate>
 </MudTable>
+<OpenEndedPager @bind-PageNumber="@gotoPage" IsLastPage="@(transactions?.Count < pageSize)" IsOptionalBottomPager="true" />
 
 @code {
     private Lexplorer.Models.Block? block;
@@ -101,7 +99,10 @@
         }
         set
         {
-            navigateTo(value, 1);
+            //blockNumber is not a query parameter, but a component (routing) parameter
+            //have not found a way to get the modified URL without knowing it
+            var URL = $"/blocks/{value.ToString()}";
+            NavigationManager.NavigateTo(URL);
         }
     }
 
@@ -113,14 +114,10 @@
         }
         set
         {
-            navigateTo(blockId, value);
+            pageNumber = value.ToString();
+            var URL = NavigationManager.GetUriWithQueryParameter(nameof(pageNumber), pageNumber);
+            NavigationManager.NavigateTo(URL);
         }
-    }
-
-    private void navigateTo(int block, int page)
-    {
-        string URL = $"blocks/{block}?pageNumber={page}";
-        NavigationManager.NavigateTo(URL);
     }
 
     public bool isTransactionLoading = true;

--- a/Lexplorer/Pages/BlocksOverview.razor
+++ b/Lexplorer/Pages/BlocksOverview.razor
@@ -9,10 +9,7 @@
     <ToolBarContent>
         <MudText Typo="Typo.h6">Latest blocks</MudText>
         <MudSpacer />
-        <MudIconButton Icon="@Icons.Filled.FirstPage" Disabled=@(gotoPage == 1) OnClick="@(() => gotoPage = 1)" />
-        <MudIconButton Icon="@Icons.Filled.NavigateBefore" Disabled=@(gotoPage == 1) OnClick="@(() => gotoPage -= 1)" />
-        <MudNumericField HideSpinButtons="true" @bind-Value="gotoPage" Label="Page" Variant="Variant.Outlined" Min="1" Margin="Margin.Dense" Class="flex-grow-0" Style="width:50px;" />
-        <MudIconButton Icon="@Icons.Filled.NavigateNext" Disabled=@(blocks?.Count < pageSize) OnClick="@(() => gotoPage += 1)" />
+        <OpenEndedPager @bind-PageNumber="@gotoPage" IsLastPage="@(blocks?.Count < pageSize)" />
         <MudSpacer />
     </ToolBarContent>
     <HeaderContent>
@@ -28,6 +25,7 @@
         <MudTd DataLabel="Timestamp">@TimestampConverter.ToUTCString(@context.timestamp!)</MudTd>
     </RowTemplate>
 </MudTable>
+<OpenEndedPager @bind-PageNumber="@gotoPage" IsLastPage="@(blocks?.Count < pageSize)" IsOptionalBottomPager="true" />
 
 @code {
     private List<BlockDetail>? blocks = new List<BlockDetail>();
@@ -44,7 +42,8 @@
         }
         set
         {
-            string URL = $"/blocks?pageNumber={value}";
+            pageNumber = value.ToString();
+            var URL = NavigationManager.GetUriWithQueryParameter(nameof(pageNumber), pageNumber);
             NavigationManager.NavigateTo(URL);
         }
     }

--- a/Lexplorer/Pages/NFTDetail.razor
+++ b/Lexplorer/Pages/NFTDetail.razor
@@ -129,10 +129,7 @@
                 <MudTable Dense="true" Striped="true" Bordered="true" Items="@transactions" Hover="true" Loading=@isLoading>
                     <ToolBarContent>
                         <MudSpacer />
-                        <MudIconButton Icon="@Icons.Filled.FirstPage" Disabled=@(gotoPage == 1) OnClick="@(() => gotoPage = 1)" />
-                        <MudIconButton Icon="@Icons.Filled.NavigateBefore" Disabled=@(gotoPage == 1) OnClick="@(() => gotoPage -= 1)" />
-                        <MudNumericField HideSpinButtons="true" @bind-Value="gotoPage" Label="Page" Variant="Variant.Outlined" Min="1" Margin="Margin.Dense" Class="flex-grow-0" Style="width:50px;" />
-                        <MudIconButton Icon="@Icons.Filled.NavigateNext" Disabled=@(transactions!.Count < pageSize) OnClick="@(() => gotoPage += 1)" />
+                        <OpenEndedPager @bind-PageNumber="gotoPage" IsLastPage="@(transactions!.Count < pageSize)" />
                         <MudSpacer />
                     </ToolBarContent>
                     <HeaderContent>
@@ -152,6 +149,7 @@
                         <MudTd DataLabel="Timestamp">@context.verifiedAt</MudTd>
                     </RowTemplate>
                 </MudTable>
+                <OpenEndedPager @bind-PageNumber="gotoPage" IsLastPage="@(transactions!.Count < pageSize)" IsOptionalBottomPager="true" />
             </ChildContent>
     </LexpansionPanel>
     <LexpansionPanel Text="Holders">
@@ -159,10 +157,7 @@
                 <MudTable Dense="true" Striped="true" Bordered="true" Items="@holders" Hover="true" Loading=@isLoadingHolders>
                     <ToolBarContent>
                         <MudSpacer />
-                        <MudIconButton Icon="@Icons.Filled.FirstPage" Disabled=@(goToHolderPage == 1) OnClick="@(() => goToHolderPage = 1)" />
-                        <MudIconButton Icon="@Icons.Filled.NavigateBefore" Disabled=@(goToHolderPage == 1) OnClick="@(() => goToHolderPage -= 1)" />
-                        <MudNumericField HideSpinButtons="true" @bind-Value="goToHolderPage" Label="Page" Variant="Variant.Outlined" Min="1" Margin="Margin.Dense" Class="flex-grow-0" Style="width:50px;" />
-                        <MudIconButton Icon="@Icons.Filled.NavigateNext" Disabled=@(holders!.Count < pageSize) OnClick="@(() => goToHolderPage += 1)" />
+                        <OpenEndedPager @bind-PageNumber="goToHolderPage" IsLastPage="@(holders!.Count < pageSize)" />
                         <MudSpacer />
                     </ToolBarContent>
                     <HeaderContent>
@@ -176,6 +171,7 @@
                         <MudTd DataLabel="Balance">@context?.balance</MudTd>
                     </RowTemplate>
                 </MudTable>
+                <OpenEndedPager @bind-PageNumber="goToHolderPage" IsLastPage="@(holders!.Count < pageSize)" IsOptionalBottomPager="true" />
             </ChildContent>
     </LexpansionPanel>
 </MudExpansionPanels>

--- a/Lexplorer/Pages/NFTOverview.razor
+++ b/Lexplorer/Pages/NFTOverview.razor
@@ -9,10 +9,7 @@
     <ToolBarContent>
         <MudText Typo="Typo.h6">Latest NFTs</MudText>
         <MudSpacer />
-        <MudIconButton Icon="@Icons.Filled.FirstPage" Disabled=@(gotoPage == 1) OnClick="@(() => gotoPage = 1)" />
-        <MudIconButton Icon="@Icons.Filled.NavigateBefore" Disabled=@(gotoPage == 1) OnClick="@(() => gotoPage -= 1)" />
-        <MudNumericField HideSpinButtons="true" @bind-Value="gotoPage" Label="Page" Variant="Variant.Outlined" Min="1" Margin="Margin.Dense" Class="flex-grow-0" Style="width:50px;" />
-        <MudIconButton Icon="@Icons.Filled.NavigateNext" Disabled=@(nfts?.Count < pageSize) OnClick="@(() => gotoPage += 1)" />
+        <OpenEndedPager @bind-PageNumber="@gotoPage" IsLastPage="@(nfts?.Count < pageSize)" />
         <MudSpacer />
     </ToolBarContent>
     <HeaderContent>
@@ -26,6 +23,7 @@
         <MudTd DataLabel="MintedBy">@LinkHelper.GetObjectLink(context.mintedAtTransaction?.minter)</MudTd>
     </RowTemplate>
 </MudTable>
+<OpenEndedPager @bind-PageNumber="@gotoPage" IsLastPage="@(nfts?.Count < pageSize)" IsOptionalBottomPager="true" />
 
 @code {
     [Parameter]
@@ -40,7 +38,9 @@
         }
         set
         {
-            navigateTo(value);
+            pageNumber = value.ToString();
+            var URL = NavigationManager.GetUriWithQueryParameter(nameof(pageNumber), pageNumber);
+            NavigationManager.NavigateTo(URL);
         }
     }
 
@@ -48,12 +48,6 @@
     public readonly int pageSize = 25;
 
     private IList<NonFungibleToken>? nfts { get; set; } = new List<NonFungibleToken>();
-
-    private void navigateTo(int page)
-    {
-        string URL = $"/nfts?pageNumber={page}";
-        NavigationManager.NavigateTo(URL);
-    }
 
     protected override async Task OnParametersSetAsync()
     {

--- a/Lexplorer/Pages/PairsOverview.razor
+++ b/Lexplorer/Pages/PairsOverview.razor
@@ -11,10 +11,7 @@
     <ToolBarContent>
         <MudText Typo="Typo.h6">Pairs</MudText>
         <MudSpacer />
-        <MudIconButton Icon="@Icons.Filled.FirstPage" Disabled=@(gotoPage == 1) OnClick="@(() => gotoPage = 1)" />
-        <MudIconButton Icon="@Icons.Filled.NavigateBefore" Disabled=@(gotoPage == 1) OnClick="@(() => gotoPage -= 1)" />
-        <MudNumericField HideSpinButtons="true" @bind-Value="gotoPage" Label="Page" Variant="Variant.Outlined" Min="1" Margin="Margin.Dense" Class="flex-grow-0" Style="width:50px;" />
-        <MudIconButton Icon="@Icons.Filled.NavigateNext" Disabled=@((pairs?.Count ?? pageSize) < pageSize) OnClick="@(() => gotoPage += 1)" />
+        <OpenEndedPager @bind-PageNumber="@gotoPage" IsLastPage="@((pairs?.Count ?? pageSize) < pageSize)" />
         <MudSpacer />
     </ToolBarContent>
     <HeaderContent>
@@ -23,9 +20,10 @@
         <MudTh Style="text-align:right">Volume 7D</MudTh>
     </HeaderContent>
     <RowTemplate>
-        <Lexplorer.Components.PairsTableDetails pair="@context" uniswapTokens="@uniswapTokens"/>
+        <Lexplorer.Components.PairsTableDetails pair="@context" uniswapTokens="@uniswapTokens" />
     </RowTemplate>
 </MudTable>
+<OpenEndedPager @bind-PageNumber="@gotoPage" IsLastPage="@((pairs?.Count ?? pageSize) < pageSize)" IsOptionalBottomPager="true" />
 
 @code {
     private List<Lexplorer.Models.Pair>? pairs { get; set; } = new();
@@ -43,14 +41,10 @@
         }
         set
         {
-            navigateTo(value);
+            pageNumber = value.ToString();
+            var URL = NavigationManager.GetUriWithQueryParameter(nameof(pageNumber), pageNumber);
+            NavigationManager.NavigateTo(URL);
         }
-    }
-
-    private void navigateTo(int page)
-    {
-        string URL = $"/pairs?pageNumber={page}";
-        NavigationManager.NavigateTo(URL);
     }
 
     public bool isLoading = true;

--- a/Lexplorer/Pages/TransactionsOverview.razor
+++ b/Lexplorer/Pages/TransactionsOverview.razor
@@ -9,10 +9,7 @@
     <ToolBarContent>
         <MudText Typo="Typo.h6">Latest transactions</MudText>
         <MudSpacer />
-        <MudIconButton Icon="@Icons.Filled.FirstPage" Disabled=@(gotoPage == 1) OnClick="@(() => gotoPage = 1)" />
-        <MudIconButton Icon="@Icons.Filled.NavigateBefore" Disabled=@(gotoPage == 1) OnClick="@(() => gotoPage -= 1)" />
-        <MudNumericField HideSpinButtons="true" @bind-Value="gotoPage" Label="Page" Variant="Variant.Outlined" Min="1" Margin="Margin.Dense" Class="flex-grow-0" Style="width:50px;" />
-        <MudIconButton Icon="@Icons.Filled.NavigateNext" Disabled=@(transactions!.Count < pageSize) OnClick="@(() => gotoPage += 1)" />
+        <OpenEndedPager @bind-PageNumber="gotoPage" IsLastPage=@(transactions!.Count < pageSize) />
         <MudSpacer />
         <MudSelect @bind-Value="@filterTransaction" T="string" Label="Filter by type">
             <MudSelectItem Value="@("All")" />
@@ -39,6 +36,8 @@
         <MudTd DataLabel="Timestamp">@context.verifiedAt</MudTd>
     </RowTemplate>
 </MudTable>
+<OpenEndedPager @bind-PageNumber="gotoPage" IsLastPage=@(transactions!.Count < pageSize) IsOptionalBottomPager="true" />
+
 
 @code {
     [Parameter]
@@ -53,7 +52,9 @@
         }
         set
         {
-            navigateTo(value);
+            pageNumber = value.ToString();
+            var URL = NavigationManager.GetUriWithQueryParameter(nameof(pageNumber), pageNumber);
+            NavigationManager.NavigateTo(URL);
         }
     }
 
@@ -75,28 +76,16 @@
         set
         {
             type = (string.Equals(value ?? "All", "All", StringComparison.InvariantCultureIgnoreCase)) ? null : value;
-            navigateTo(gotoPage);
+            var URL = NavigationManager.GetUriWithQueryParameter(nameof(type), type);
+            NavigationManager.NavigateTo(URL);
         }
-    }
-
-    private void navigateTo(int page)
-    {
-        string URL = $"/transactions?pageNumber={page}";
-        if (type != null)
-            URL += $"&type={type}";
-        NavigationManager.NavigateTo(URL);
     }
 
     protected override async Task OnParametersSetAsync()
     {
         isLoading = true;
 
-        if (string.IsNullOrEmpty(pageNumber))
-        {
-            pageNumber = "1";
-        }
-
-        string transactionCacheKey = $"transactions-page{pageNumber}-type{type}";
+        string transactionCacheKey = $"transactions-page{gotoPage}-type{type}";
         var transactionsData = await AppCache.GetOrAddAsyncNonNull(transactionCacheKey,
             async () => await LoopringGraphQLService.GetTransactions((gotoPage - 1) * pageSize, pageSize, typeName: type),
             DateTimeOffset.UtcNow.AddMinutes(10));
@@ -105,4 +94,4 @@
         StateHasChanged();
     }
 
-    }
+}


### PR DESCRIPTION
As described in #119 

The component itself doesn't result in a different appearance.

But all the places now have an optional 2nd pager at the bottom (similar to NFTGrid as described in #150) when on smaller devices:

<img width="1004" alt="image" src="https://user-images.githubusercontent.com/44807458/177037382-7cd9e9e5-beb8-4e7b-a83e-8a73976ac248.png">
