### PR TITLE
Model cleanup

### DIFF
--- a/Lexplorer/Components/HomepageOverview.razor
+++ b/Lexplorer/Components/HomepageOverview.razor
@@ -187,8 +187,7 @@
         transactionData = await AppCache.GetOrAddAsyncNonNull(transactionCacheKey, async () => await LoopringGraphQLService.GetTransactions(0, 10), DateTimeOffset.UtcNow.AddMinutes(10));
         StateHasChanged();
         string pairsCacheKey = $"homepage-pairs";
-        var pairsData = await AppCache.GetOrAddAsyncNonNull(pairsCacheKey, async () => await LoopringGraphQLService.GetPairs(), DateTimeOffset.UtcNow.AddHours(1));
-        pairs = pairsData?.data?.pairs;
+        pairs = await AppCache.GetOrAddAsyncNonNull(pairsCacheKey, async () => await LoopringGraphQLService.GetPairs(), DateTimeOffset.UtcNow.AddHours(1));
         foreach (var pair in pairs!)
         {
             if (string.IsNullOrEmpty(pair.token1?.address)) continue;

--- a/Lexplorer/Components/HomepageOverview.razor
+++ b/Lexplorer/Components/HomepageOverview.razor
@@ -6,14 +6,14 @@
 
     <MudGrid>
         <MudItem sm="12">
-            <p hidden="@(transactionData != null)"><MudProgressLinear Color="Color.Primary" Indeterminate="true" Class="my-7" /></p>
+            <p hidden="@(proxy != null)"><MudProgressLinear Color="Color.Primary" Indeterminate="true" Class="my-7" /></p>
         </MudItem>
         <MudItem xs="12" md="6" lg="4">
             <MudCard Style="height:100%;position:relative">
                 <MudCardContent>
                     <MudText Typo="Typo.h6" Align="Align.Center">Total Transactions</MudText>
                     <MudText Typo="Typo.body1" Align="Align.Center">
-                        @blockData?.data?.proxy?.transactionCount.ToString("N0")
+                        @proxy?.transactionCount.ToString("N0")
                         <MudText Color="Color.Primary">+@dailyCount.TransactionCount.ToString("N0") in 24 hours</MudText>
                     </MudText>
                 </MudCardContent>
@@ -24,7 +24,7 @@
                 <MudCardContent>
                     <MudText Typo="Typo.h6" Align="Align.Center">Total Blocks</MudText>
                     <MudText Typo="Typo.body1" Align="Align.Center">
-                        @blockData?.data?.proxy?.blockCount.ToString("N0")
+                        @proxy?.blockCount.ToString("N0")
                         <MudText Color="Color.Primary">+@dailyCount.BlockCount.ToString("N0") in 24 hours</MudText>
                     </MudText>
                 </MudCardContent>
@@ -35,7 +35,7 @@
                 <MudCardContent>
                     <MudText Typo="Typo.h6" Align="Align.Center">Total L2 Accounts</MudText>
                     <MudText Typo="Typo.body1" Align="Align.Center">
-                        @blockData?.data?.proxy?.userCount.ToString("N0")
+                        @proxy?.userCount.ToString("N0")
                         <MudText Color="Color.Primary">+@dailyCount.UserCount.ToString("N0") in 24 hours</MudText>
                     </MudText>
                 </MudCardContent>
@@ -70,7 +70,7 @@
                 <MudCardContent>
                     <MudText Typo="Typo.h6" Align="Align.Center">NFT Mint Count</MudText>
                     <MudText Typo="Typo.body1" Align="Align.Center">
-                        @blockData?.data?.proxy?.nftMintCount.ToString("N0")
+                        @proxy?.nftMintCount.ToString("N0")
                         <MudText Color="Color.Primary">+@dailyCount.NFTMintCount.ToString("N0") in 24 hours</MudText>
                     </MudText>
                 </MudCardContent>
@@ -81,7 +81,7 @@
                 <MudCardContent>
                     <MudText Typo="Typo.h6" Align="Align.Center">NFT Trade Count</MudText>
                     <MudText Typo="Typo.body1" Align="Align.Center">
-                        @blockData?.data?.proxy?.tradeNFTCount.ToString("N0")
+                        @proxy?.tradeNFTCount.ToString("N0")
                         <MudText Color="Color.Primary">+@dailyCount.TradeNFTCount.ToString("N0") in 24 hours</MudText>
                     </MudText>
                 </MudCardContent>
@@ -92,7 +92,7 @@
                 <MudCardContent>
                     <MudText Typo="Typo.h6" Align="Align.Center">NFT Transfer Count</MudText>
                     <MudText Typo="Typo.body1" Align="Align.Center">
-                        @blockData?.data?.proxy?.transferNFTCount.ToString("N0")
+                        @proxy?.transferNFTCount.ToString("N0")
                         <MudText Color="Color.Primary">+@dailyCount.TransferNFTCount.ToString("N0") in 24 hours</MudText>
                     </MudText>
                 </MudCardContent>
@@ -102,7 +102,7 @@
 
     <MudGrid>
         <MudItem xs="12" sm="12" md="12">
-            <MudTable Dense="true" Items="@transactionData?.data?.transactions" Hover="true">
+            <MudTable Dense="true" Items="@transactions" Hover="true">
                 <ToolBarContent>
                     <MudText Typo="Typo.h6">Latest Transactions</MudText>
                 </ToolBarContent>
@@ -120,13 +120,13 @@
                     <MudTd DataLabel="Transaction Id">@LinkHelper.GetObjectLink(context)</MudTd>
                     <MudTd DataLabel="Type">@context.typeName</MudTd>
                     <TransactionTableDetails TransactionData=@context />
-                    <MudTd DataLabel="Timestamp">@TimestampConverter.ToUTCString(@blockData?.data?.blocks?[0].timestamp)</MudTd>
+                    <MudTd DataLabel="Timestamp">@TimestampConverter.ToUTCString(@blocks?[0].timestamp)</MudTd>
                 </RowTemplate>
             </MudTable>
             <MudButton Variant="Variant.Filled" Color="Color.Primary" FullWidth="true" OnClick="GoToTransactionOverviewPage">View more transactions</MudButton>
         </MudItem>
         <MudItem xs="12" sm="12" md="6">
-            <MudTable Dense="true" Items="@blockData?.data?.blocks" Hover="true">
+            <MudTable Dense="true" Items="@blocks" Hover="true">
                 <ToolBarContent>
                     <MudText Typo="Typo.h6">Latest Blocks</MudText>
                 </ToolBarContent>
@@ -164,8 +164,9 @@
     </MudGrid>
 @code
 {
-    private Blocks? blockData;
-    private Transactions? transactionData;
+    private List<Lexplorer.Models.Block>? blocks;
+    private List<Transaction>? transactions;
+    private Proxy? proxy;
     private List<Lexplorer.Models.Pair>? pairs { get; set; } = new();
     private Dictionary<string, UniswapToken> uniswapTokens = new();
     private LoopStatsDailyCount dailyCount { get; set; } = new();
@@ -177,14 +178,22 @@
     protected override async Task OnInitializedAsync()
     {
         string dailyCacheKey = "homepage-daily";
-        dailyCount = await AppCache.GetOrAddAsyncNonNull(dailyCacheKey, async () => await LoopStatsService.GetDailyCount(), DateTimeOffset.UtcNow.AddMinutes(10));
+        dailyCount = await AppCache.GetOrAddAsyncNonNull(dailyCacheKey,
+            async () => await LoopStatsService.GetDailyCount(),
+            DateTimeOffset.UtcNow.AddMinutes(10));
         string blockCacheKey = $"homepage-block";
-        blockData = await AppCache.GetOrAddAsyncNonNull(blockCacheKey, async () => await LoopringGraphQLService.GetBlocks(0, 10), DateTimeOffset.UtcNow.AddMinutes(10));
+        var blockAndProxyDTO = await AppCache.GetOrAddAsyncNonNull(blockCacheKey,
+            async () => await LoopringGraphQLService.GetBlocks(0, 10),
+            DateTimeOffset.UtcNow.AddMinutes(10));
+        blocks = blockAndProxyDTO?.blocks;
+        proxy = blockAndProxyDTO?.proxy;
         CalculateAverageBlockTime();
         CalculateLastBlockSubmitted();
         StateHasChanged();
         string transactionCacheKey = $"homepage-transaction";
-        transactionData = await AppCache.GetOrAddAsyncNonNull(transactionCacheKey, async () => await LoopringGraphQLService.GetTransactions(0, 10), DateTimeOffset.UtcNow.AddMinutes(10));
+        transactions = await AppCache.GetOrAddAsyncNonNull(transactionCacheKey,
+            async () => await LoopringGraphQLService.GetTransactions(0, 10),
+            DateTimeOffset.UtcNow.AddMinutes(10));
         StateHasChanged();
         string pairsCacheKey = $"homepage-pairs";
         pairs = await AppCache.GetOrAddAsyncNonNull(pairsCacheKey, async () => await LoopringGraphQLService.GetPairs(), DateTimeOffset.UtcNow.AddHours(1));
@@ -207,20 +216,20 @@
         long transactionCount = 0;
         long currentTime = DateTimeOffset.Now.ToUnixTimeSeconds();
         List<long> timeBetweenBlocks = new List<long>();
-        foreach (var block in blockData!.data!.blocks!)
+        foreach (var block in blocks!)
         {
             transactionCount += block.transactionCount;
             timeBetweenBlocks.Add(currentTime - long.Parse(block.timestamp!));
             currentTime = long.Parse(block.timestamp!);
         }
-        averageTransactions = transactionCount / blockData.data.blocks.Count;
+        averageTransactions = transactionCount / blocks.Count;
         averageBlockTime = Math.Floor(timeBetweenBlocks.Average() / 60);
     }
 
     private void CalculateLastBlockSubmitted()
     {
         long currentTime = DateTimeOffset.Now.ToUnixTimeSeconds();
-        long timeSinceLastBlock = currentTime - long.Parse(blockData!.data!.blocks![0].timestamp!);
+        long timeSinceLastBlock = currentTime - long.Parse(blocks![0].timestamp!);
         lastBlockSubmittedTime = Math.Floor((double)timeSinceLastBlock / 60);
     }
 

--- a/Lexplorer/Helpers/LinkHelper.cs
+++ b/Lexplorer/Helpers/LinkHelper.cs
@@ -39,8 +39,8 @@
         {
             if (linkedObject is Account)
                 return new Tuple<string, string>($"account/{((Account)linkedObject).id}", ((Account)linkedObject).id ?? "");
-            else if (linkedObject is BlockDetail)
-                return new Tuple<string, string>($"blocks/{((BlockDetail)linkedObject).id}", ((BlockDetail)linkedObject).id ?? "");
+            else if (linkedObject is Block)
+                return new Tuple<string, string>($"blocks/{((Block)linkedObject).id}", ((Block)linkedObject).id ?? "");
             else if (linkedObject is Transaction)
                 return new Tuple<string, string>($"transactions/{((Transaction)linkedObject).id}", 
                     ((Transaction)linkedObject).id ?? "");

--- a/Lexplorer/Pages/BlockDetails.razor
+++ b/Lexplorer/Pages/BlockDetails.razor
@@ -14,8 +14,8 @@
                 <div>
                     <MudIconButton Icon="@Icons.Filled.FirstPage" Disabled=@(blockId == 1) OnClick="@(() => blockId = 1)" />
                     <MudIconButton Icon="@Icons.Filled.NavigateBefore" Disabled=@(blockId == 1) OnClick="@(() => blockId -= 1)" />
-                    <MudText Typo="Typo.h6" Inline="true">Block #@block?.data?.block?.id</MudText>
-                    <MudIconButton Icon="@Icons.Filled.NavigateNext" Disabled=@(blockId == (block?.data?.proxy?.blockCount ?? 0)) OnClick="@(() => blockId += 1)" />
+                    <MudText Typo="Typo.h6" Inline="true">Block #@block?.id</MudText>
+                    <MudIconButton Icon="@Icons.Filled.NavigateNext" Disabled=@(blockId == (proxy?.blockCount ?? 0)) OnClick="@(() => blockId += 1)" />
                 </div>
             </td>
         </tr>
@@ -29,24 +29,24 @@
         }
         <tr>
             <td>Block Hash</td>
-            <td>@block?.data?.block?.blockHash</td>
+            <td>@block?.blockHash</td>
         </tr>
         <tr>
             <td>Block Size</td>
-            <td>@block?.data?.block?.blockSize</td>
+            <td>@block?.blockSize</td>
         </tr>
         <tr>
             <td>L1 Transaction Hash</td>
-            <td><L1TransactionLink txHash="@block?.data?.block?.txHash" shortenHash="false"></L1TransactionLink></td>
+            <td><L1TransactionLink txHash="@block?.txHash" shortenHash="false"></L1TransactionLink></td>
         </tr>
         <tr>
             <td>Verified At (UTC)</td>
-            <td>@TimestampConverter.ToUTCString(block?.data?.block?.timestamp!)</td>
+            <td>@TimestampConverter.ToUTCString(block?.timestamp!)</td>
         </tr>
         <tr>
             <td>Raw Data</td>
             <td>
-                <MudTextField T="string" Variant="Variant.Filled" Text="@block?.data?.block?.data" Lines="5" ReadOnly="true" />
+                <MudTextField T="string" Variant="Variant.Filled" Text="@block?.data" Lines="5" ReadOnly="true" />
             </td>
         </tr>
     </tbody>
@@ -56,7 +56,7 @@
 
 <MudTable Dense="true" Items="@transactions" Hover="true" Loading="@isTransactionLoading">
     <ToolBarContent>
-        <MudText Typo="Typo.h6">Transactions in block #@block?.data?.block?.id</MudText>
+        <MudText Typo="Typo.h6">Transactions in block #@block?.id</MudText>
         <MudSpacer />
         <OpenEndedPager @bind-PageNumber="@gotoPage" IsLastPage="@(transactions?.Count < pageSize)" />
         <MudSpacer />
@@ -75,13 +75,14 @@
         <MudTd DataLabel="Tx Id">@LinkHelper.GetObjectLink(context)</MudTd>
         <MudTd DataLabel="Type">@context.typeName</MudTd>
         <TransactionTableDetails TransactionData=@context />
-        <MudTd DataLabel="Time">@TimestampConverter.ToUTCString(@block?.data?.block?.timestamp)</MudTd>
+        <MudTd DataLabel="Time">@TimestampConverter.ToUTCString(@block?.timestamp)</MudTd>
     </RowTemplate>
 </MudTable>
 <OpenEndedPager @bind-PageNumber="@gotoPage" IsLastPage="@(transactions?.Count < pageSize)" IsOptionalBottomPager="true" />
 
 @code {
     private Lexplorer.Models.Block? block;
+    private Proxy? proxy;
     private List<Transaction>? transactions = new();
 
     [Parameter]
@@ -140,19 +141,20 @@
                 transactions = new List<Transaction>();
                 isBlockLoading = true;
                 string blockCacheKey = $"blockDetailOverview-{blockId}";
-                block = await AppCache.GetOrAddAsyncNonNull(blockCacheKey,
+                var blockDTO = await AppCache.GetOrAddAsyncNonNull(blockCacheKey,
                     async () => await LoopringGraphQLService.GetBlockDetails(blockId, localCTS.Token),
                     DateTimeOffset.UtcNow.AddMinutes(5));
+                block = blockDTO?.block;
+                proxy = blockDTO?.proxy;
                 if (block == null) return;
                 isBlockLoading = false;
                 isTransactionLoading = true;
                 StateHasChanged();
 
                 string transactionDatacacheKey = $"blockDetailTransactions-{blockId}-page{gotoPage}";
-                var transactionData = await AppCache.GetOrAddAsyncNonNull(transactionDatacacheKey,
+                transactions = await AppCache.GetOrAddAsyncNonNull(transactionDatacacheKey,
                     async () => await LoopringGraphQLService.GetTransactions((gotoPage - 1) * pageSize, pageSize, blockId: blockNumber, cancellationToken: localCTS.Token),
-                    DateTimeOffset.UtcNow.AddMinutes(5));
-                transactions = transactionData?.data?.transactions ?? new List<Transaction>();
+                    DateTimeOffset.UtcNow.AddMinutes(5)) ?? new List<Transaction>();
                 isTransactionLoading = false;
                 StateHasChanged();
 

--- a/Lexplorer/Pages/BlocksOverview.razor
+++ b/Lexplorer/Pages/BlocksOverview.razor
@@ -28,7 +28,8 @@
 <OpenEndedPager @bind-PageNumber="@gotoPage" IsLastPage="@(blocks?.Count < pageSize)" IsOptionalBottomPager="true" />
 
 @code {
-    private List<BlockDetail>? blocks = new List<BlockDetail>();
+    private List<Lexplorer.Models.Block>? blocks = new();
+    private Proxy? proxy;
 
     [Parameter]
     [SupplyParameterFromQuery]
@@ -56,10 +57,11 @@
     {
         isLoading = true;
         string blockCacheKey = $"blocks-{gotoPage}";
-        var blockData = await AppCache.GetOrAddAsyncNonNull(blockCacheKey,
+        var blocksDTO = await AppCache.GetOrAddAsyncNonNull(blockCacheKey,
             async () => await LoopringGraphQLService.GetBlocks((gotoPage - 1) * pageSize, pageSize),
             DateTimeOffset.UtcNow.AddMinutes(10));
-        blocks = blockData?.data?.blocks ?? new List<BlockDetail>();
+        blocks = blocksDTO?.blocks ?? new();
+        proxy = blocksDTO?.proxy;
         isLoading = false;
         StateHasChanged();
     }

--- a/Lexplorer/Pages/PairsOverview.razor
+++ b/Lexplorer/Pages/PairsOverview.razor
@@ -58,10 +58,9 @@
         }
         isLoading = true;
         string pairsCacheKey = $"pairsOverview-pairs-page{pageNumber}";
-        var pairsData = await AppCache.GetOrAddAsyncNonNull(pairsCacheKey,
+        pairs = await AppCache.GetOrAddAsyncNonNull(pairsCacheKey,
             async () => await LoopringGraphQLService.GetPairs((gotoPage - 1) * pageSize, pageSize),
             DateTimeOffset.UtcNow.AddHours(1));
-        pairs = pairsData?.data?.pairs;
         if (pairs == null) return;
         foreach (var pair in pairs!)
         {

--- a/Lexplorer/Pages/TransactionsOverview.razor
+++ b/Lexplorer/Pages/TransactionsOverview.razor
@@ -86,10 +86,9 @@
         isLoading = true;
 
         string transactionCacheKey = $"transactions-page{gotoPage}-type{type}";
-        var transactionsData = await AppCache.GetOrAddAsyncNonNull(transactionCacheKey,
+        transactions = await AppCache.GetOrAddAsyncNonNull(transactionCacheKey,
             async () => await LoopringGraphQLService.GetTransactions((gotoPage - 1) * pageSize, pageSize, typeName: type),
             DateTimeOffset.UtcNow.AddMinutes(10));
-        transactions = transactionsData?.data?.transactions;
         isLoading = false;
         StateHasChanged();
     }

--- a/Shared/Models/LoopringV3.cs
+++ b/Shared/Models/LoopringV3.cs
@@ -19,7 +19,7 @@ namespace Lexplorer.Models
         }
     }
 
-    public class BlockDetail
+    public class Block
     {
         [JsonProperty("__typename")]
         public string? typeName { get; set; }
@@ -52,27 +52,18 @@ namespace Lexplorer.Models
         public long withdrawalNFTCount { get; set; }
     }
 
-    public class BlockData
+    public class BlockAndProxyDTO
     {
-        public BlockDetail? block { get; set; }
+        public Block? block { get; set; }
         public Proxy? proxy { get; set; }
     }
 
-    public class Block
+    public class BlocksAndProxyDTO
     {
-        public BlockData? data { get; set; }
-    }
-
-    public class BlocksData
-    {
-        public List<BlockDetail>? blocks { get; set; }
+        public List<Block>? blocks { get; set; }
         public Proxy? proxy { get; set; }
     }
 
-    public class Blocks
-    {
-        public BlocksData? data { get; set; }
-    }
     public class Proxy
     {
         public long accountUpdateCount { get; set; }
@@ -190,7 +181,7 @@ namespace Lexplorer.Models
         [JsonProperty(PropertyName = "__typename")]
         public string? typeName { get; set; }
         public string? data { get; set; }
-        public BlockDetail? block { get; set; }
+        public Block? block { get; set; }
         public List<AccountTokenBalance>? tokenBalances { get; set; }
         public List<Account>? accounts { get; set; }
         public string? verifiedAt
@@ -459,17 +450,6 @@ namespace Lexplorer.Models
                 }
             }
         }
-    }
-
-    public class TransactionsData
-    {
-        public Proxy? proxy { get; set; }
-        public List<Transaction>? transactions { get; set; }
-    }
-
-    public class Transactions
-    {
-        public TransactionsData? data { get; set; }
     }
 
     public class PairEntity

--- a/Shared/Models/LoopringV3.cs
+++ b/Shared/Models/LoopringV3.cs
@@ -472,16 +472,6 @@ namespace Lexplorer.Models
         public TransactionsData? data { get; set; }
     }
 
-    public class Pairs
-    {
-        public PairsData? data { get; set; }
-    }
-
-    public class PairsData
-    {
-        public List<Pair>? pairs { get; set; }
-    }
-
     public class PairEntity
     {
         public string? id { get; set; }

--- a/Shared/Services/LoopringGraphQLService.cs
+++ b/Shared/Services/LoopringGraphQLService.cs
@@ -819,7 +819,7 @@ namespace Lexplorer.Services
 
             return count;
         }
-        public async Task<Pairs?> GetPairs(int skip = 0, int first = 10, string orderBy = "tradedVolumeToken0Swap", string orderDirection = "desc")
+        public async Task<List<Pair>?> GetPairs(int skip = 0, int first = 10, string orderBy = "tradedVolumeToken0Swap", string orderDirection = "desc")
         {
             var pairsQuery = @"
              query pairs(
@@ -878,8 +878,9 @@ namespace Lexplorer.Services
             try
             {
                 var response = await _client.PostAsync(request);
-                var data = JsonConvert.DeserializeObject<Pairs>(response.Content!);
-                return data;
+                JObject jresponse = JObject.Parse(response.Content!);
+                JToken? jtoken = jresponse["data"]!["pairs"];
+                return jtoken!.ToObject<List<Pair>>()!;
             }
             catch (Exception ex)
             {

--- a/Shared/Services/LoopringGraphQLService.cs
+++ b/Shared/Services/LoopringGraphQLService.cs
@@ -931,7 +931,6 @@ namespace Lexplorer.Services
             try
             {
                 var response = await _client.PostAsync(request);
-                var data = JsonConvert.DeserializeObject<Pairs>(response.Content!);
                 JObject jresponse = JObject.Parse(response.Content!);
                 JToken? token = jresponse["data"]!["pair"];
                 return token!.ToObject<Pair>();
@@ -1005,7 +1004,6 @@ namespace Lexplorer.Services
             try
             {
                 var response = await _client.PostAsync(request);
-                var data = JsonConvert.DeserializeObject<Pairs>(response.Content!);
                 JObject jresponse = JObject.Parse(response.Content!);
                 JToken? token = jresponse["data"]!["pair"]!["dailyEntities"];
                 return token!.ToObject<IList<PairDailyData>>();

--- a/Shared/Services/LoopringGraphQLService.cs
+++ b/Shared/Services/LoopringGraphQLService.cs
@@ -33,7 +33,7 @@ namespace Lexplorer.Services
             _client = new RestClient(baseUrl);
         }
 
-        public async Task<Blocks?> GetBlocks(int skip, int first, string orderBy = "internalID",
+        public async Task<BlocksAndProxyDTO?> GetBlocks(int skip, int first, string orderBy = "internalID",
             string orderDirection = "desc", string? blockTimestamp = null, bool gte = true)
         {
             var blocksQuery = @"
@@ -107,8 +107,8 @@ namespace Lexplorer.Services
             try
             {
                 var response = await _client.PostAsync(request);
-                var data = JsonConvert.DeserializeObject<Blocks>(response.Content!);
-                return data;
+                var jtoken = JToken.Parse(response.Content!);
+                return jtoken["data"]!.ToObject<BlocksAndProxyDTO>();
             }
             catch (Exception ex)
             {
@@ -175,7 +175,7 @@ namespace Lexplorer.Services
 
         }
 
-        public async Task<Block?> GetBlockDetails(int blockId, CancellationToken cancellationToken = default)
+        public async Task<BlockAndProxyDTO?> GetBlockDetails(int blockId, CancellationToken cancellationToken = default)
         {
             var blockQuery = @"
             query block($id: ID!) {
@@ -219,8 +219,8 @@ namespace Lexplorer.Services
                 }
             });
             var response = await _client.PostAsync(request, cancellationToken);
-            var data = JsonConvert.DeserializeObject<Block>(response.Content!);
-            return data;
+            var jToken = JToken.Parse(response.Content!);
+            return jToken["data"]!.ToObject<BlockAndProxyDTO>();
         }
 
         public async Task<Transaction?> GetTransaction(string transactionId)
@@ -303,7 +303,7 @@ namespace Lexplorer.Services
             }
         }
 
-        public async Task<Transactions?> GetTransactions(int skip, int first, string? blockId = null, string? typeName = null, CancellationToken cancellationToken = default)
+        public async Task<List<Transaction>?> GetTransactions(int skip, int first, string? blockId = null, string? typeName = null, CancellationToken cancellationToken = default)
         {
             var transactionsQuery = @"
               query transactions(
@@ -313,25 +313,6 @@ namespace Lexplorer.Services
                 $orderDirection: OrderDirection
                 $whereFilter: Transaction_filter
               ) {
-                proxy(id: 0) {
-                  transactionCount
-                  depositCount
-                  withdrawalCount
-                  transferCount
-                  addCount
-                  removeCount
-                  orderbookTradeCount
-                  swapCount
-                  accountUpdateCount
-                  ammUpdateCount
-                  signatureVerificationCount
-                  tradeNFTCount
-                  swapNFTCount
-                  withdrawalNFTCount
-                  transferNFTCount
-                  nftMintCount
-                  nftDataCount
-                }
                 transactions(
                   skip: $skip
                   first: $first
@@ -425,8 +406,8 @@ namespace Lexplorer.Services
             try
             {
                 var response = await _client.PostAsync(request, cancellationToken);
-                var data = JsonConvert.DeserializeObject<Transactions>(response.Content!);
-                return data;
+                var jtoken = JToken.Parse(response.Content!);
+                return jtoken["data"]!["transactions"]!.ToObject<List<Transaction>>();
             }
             catch (Exception ex)
             {
@@ -1021,7 +1002,7 @@ namespace Lexplorer.Services
         {
                 { "accounts", typeof(Account) },
                 { "accountsByAddress", typeof(Account) },
-                { "blocks", typeof(BlockDetail) },
+                { "blocks", typeof(Block) },
                 { "transactions", typeof(Transaction) },
                 { "nonFungibleTokens", typeof(NonFungibleToken) },
                 { "nonFungibleTokensBynftID", typeof(NonFungibleToken) },

--- a/xUnitTests/LoopringGraphTests/TestBlock.cs
+++ b/xUnitTests/LoopringGraphTests/TestBlock.cs
@@ -25,18 +25,17 @@ namespace xUnitTests.LoopringGraphTests
         [Fact]
         public async void GetBlocks()
         {
-            Blocks? blocks = await service.GetBlocks(0, 10);
-            Assert.NotNull(blocks);
-            Assert.NotEmpty(blocks!.data!.blocks!);
-            Assert.Equal(10, blocks!.data!.blocks!.Count);
+            var blocksDTO = await service.GetBlocks(0, 10);
+            Assert.NotEmpty(blocksDTO!.blocks);
+            Assert.Equal(10, blocksDTO!.blocks!.Count);
         }
         [Fact]
         public async void GetBlockByDate()
         {
-            Blocks? blocks = await service.GetBlocks(0, 1, blockTimestamp: "1643909000", gte: false);
-            Assert.NotNull(blocks);
-            Assert.Single(blocks!.data!.blocks!);
-            Assert.Equal("16791", blocks!.data!.blocks![0].id);
+            var blocksDTO = await service.GetBlocks(0, 1, blockTimestamp: "1643909000", gte: false);
+            Assert.NotNull(blocksDTO);
+            Assert.Single(blocksDTO?.blocks!);
+            Assert.Equal("16791", blocksDTO!.blocks![0].id);
         }
         [Fact]
         public async void GetBlockDateRange()

--- a/xUnitTests/LoopringGraphTests/TestPairs.cs
+++ b/xUnitTests/LoopringGraphTests/TestPairs.cs
@@ -24,9 +24,8 @@ namespace xUnitTests.LoopringGraphTests
         public async void GetPairs()
         {
             var pairs = await service.GetPairs(0, 10);
-            Assert.NotNull(pairs?.data);
-            Assert.NotEmpty(pairs!.data!.pairs);
-            Assert.Equal(10, pairs!.data!.pairs!.Count);
+            Assert.NotEmpty(pairs);
+            Assert.Equal(10, pairs!.Count);
         }
 
         [Theory]

--- a/xUnitTests/LoopringGraphTests/TestSearch.cs
+++ b/xUnitTests/LoopringGraphTests/TestSearch.cs
@@ -28,7 +28,7 @@ namespace xUnitTests.LoopringGraphTests
             Assert.NotNull(searchResult);
             Assert.Equal(2, searchResult!.Count);
             Assert.IsType<User>(searchResult[0]);
-            Assert.IsType<BlockDetail>(searchResult[1]);
+            Assert.IsType<Block>(searchResult[1]);
         }
 
         [Fact]

--- a/xUnitTests/LoopringGraphTests/TestTransaction.cs
+++ b/xUnitTests/LoopringGraphTests/TestTransaction.cs
@@ -32,11 +32,10 @@ namespace xUnitTests.LoopringGraphTests
         public async void TestGetTransations(string? typeName)
         {
             var transactions = await service.GetTransactions(0, 5, typeName: typeName);
-            Assert.NotNull(transactions);
-            Assert.NotEmpty(transactions?.data?.transactions);
+            Assert.NotEmpty(transactions);
             if (!string.IsNullOrEmpty(typeName))
             {
-                foreach (var transaction in transactions?.data?.transactions!)
+                foreach (var transaction in transactions!)
                 {
                     Assert.Equal(typeName, transaction.typeName);
                 }
@@ -48,8 +47,7 @@ namespace xUnitTests.LoopringGraphTests
         public async void TestGetBlockTransations(string? blockId)
         {
             var transactions = await service.GetTransactions(0, 5, blockId: blockId);
-            Assert.NotNull(transactions);
-            Assert.NotEmpty(transactions?.data?.transactions);
+            Assert.NotEmpty(transactions);
         }
     }
 }


### PR DESCRIPTION
* removed several helper classes which were just made to match the JSON structure
* no longer necessary if accessing tokens like "data" directly before deserialisation
* renamed two helper classes with DTO suffix for GetBlockDetails and GetBlocks - the only two queries that retrieve the proxy in addition to the actual entities (Block and List<Block>)
* GetTransactions no longer retrieves proxy - wasn't used
* adapted all tests and pages/components to the new structure which helped reduce a lot of code and we're no closer to the graph entity names again