### PR TITLE
Fix #223 forcing break on lengthy NFT titles

### DIFF
--- a/Lexplorer/Components/NFTGrid.razor
+++ b/Lexplorer/Components/NFTGrid.razor
@@ -25,7 +25,7 @@
                 <MudCard Style="height:100%;position:relative" Class="ma-1 border-solid">
                     <MudCardMedia Image="@NftMetadataService.MakeIPFSLink(metaData?.image)" Style="object-fit:contain" />
                     <MudCardContent>
-                        <MudText Typo="Typo.h6">@metaData?.name</MudText>
+                        <MudText Typo="Typo.h6" Style="word-break: break-all;">@metaData?.name</MudText>
                         @if (slot.balance > 0)
                         { 
                             <MudChip Label="true" Color="Color.Primary" Class="ml-0">x @slot.balance.ToString("#,##0")</MudChip>


### PR DESCRIPTION
Closes #223 

Screenshot with the fix applied (as opposed to the one in the issue):

<img width="1565" alt="image" src="https://user-images.githubusercontent.com/44807458/178509219-b639ae08-d3f8-4af2-a8d9-6e9b552844b7.png">
