### PR TITLE
Set of smaller token related improvements

### DIFF
--- a/Lexplorer/Pages/TokenDetails.razor
+++ b/Lexplorer/Pages/TokenDetails.razor
@@ -9,26 +9,30 @@
 @inject LoopringPoolTokenCacheService poolTokenCacheService;
 @inject UniswapGraphQLService UniswapGraphQLService;
 
-<PageTitle>The Lexplorer - token @(token?.symbol) </PageTitle>
+<PageTitle>The Lexplorer - token @(token?.failSafeSymbol) </PageTitle>
 
 <MudSimpleTable Dense="true" Striped="true" Bordered="true">
     <tbody>
         <tr>
             <td colspan="2">
                 <div class="mud-toolbar mud-toolbar-gutters mud-table-toolbar">
-                    <MudText Typo="Typo.h6">Token @token?.symbol (@token?.name)</MudText>
+                    <MudText Typo="Typo.h6">Token @token?.failSafeSymbol (@token?.name)</MudText>
                 </div>
             </td>
+        </tr>
+        <tr>
+            <td>Address</td>
+            <td><L1AccountLink address="@token?.address" /></td>
         </tr>
         <tr>
             <td>Total volume</td>
             <td>@TokenAmountConverter.ToStringWithExponent(token?.tradedVolume ?? 0, token?.decimals ?? 0, 1) @token?.symbol </td>
         </tr>
-        @if (uniswapToken != null)
+        @if ((uniswapToken?.data?.tokenDayDatas?.Count ?? 0) > 0)
         {
             <tr>
                 <td>Price</td>
-                <td>@uniswapToken.data?.tokenDayDatas?.FirstOrDefault()?.priceUSD.ToString("C", System.Globalization.CultureInfo.GetCultureInfo("en-US"))</td>
+                <td>@uniswapToken?.data?.tokenDayDatas?.FirstOrDefault()?.priceUSD.ToString("C", System.Globalization.CultureInfo.GetCultureInfo("en-US"))</td>
             </tr>
         }
         @if (poolToken != null)

--- a/Shared/Helpers/TimestampConverter.cs
+++ b/Shared/Helpers/TimestampConverter.cs
@@ -15,9 +15,7 @@ namespace Lexplorer.Helpers
         public static DateTime? ToUTCDateTime(string? unixTimeStamp)
         {
             if (unixTimeStamp == null) return null;
-            // Unix timestamp is seconds past epoch
-            DateTime dateTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
-            return dateTime.AddSeconds(double.Parse(unixTimeStamp)).ToLocalTime().ToUniversalTime();
+            return DateTimeOffset.FromUnixTimeSeconds(long.Parse(unixTimeStamp)).UtcDateTime;
         }
 
         public static double? ToTimeStamp(DateTime? dateTimeUTC)

--- a/Shared/Services/LoopringPoolTokenCacheService.cs
+++ b/Shared/Services/LoopringPoolTokenCacheService.cs
@@ -21,8 +21,8 @@ namespace Lexplorer.Services
 
 		private void AddCachedPoolToken(LoopringPoolToken token)
         {
-            token.token!.name = $"LP-{token.pair!.token0!.symbol!.ToUpper()}-{token.pair!.token1!.symbol!.ToUpper()}";
-            token.token!.symbol = token.token.name;
+            token.token!.name = $"AMM-{token.pair!.token0!.failSafeSymbol!.ToUpper()}-{token.pair!.token1!.failSafeSymbol!.ToUpper()}";
+            token.token!.symbol = $"LP-{token.pair!.token0!.failSafeSymbol!.ToUpper()}-{token.pair!.token1!.failSafeSymbol!.ToUpper()}";
             token.token!.decimals = 8; //seems to be contant, see https://github.com/Loopring/protocols/blob/release_loopring_3.6.3/packages/loopring_v3/contracts/amm/PoolToken.sol
             poolTokensByTokenID.Add(token.token!.id!, token);
 			poolTokensByPairTokenIDs.Add(new(token.pair!.token0!.id!, token.pair!.token1!.id!), token);


### PR DESCRIPTION
* token details page
  * use failSafeSymbol in case symbol is empty so "Token {id}" is displayed
  * show token address with link to etherscan to check the contract
* adapt pool token naming convention so they match that of the contracts
  * i.e. name = AMM-x-y, symbol = LP-x-y
* refactored TimestampConverter.ToUTCTime() as suggested on discord