### PR TITLE
Feature/fetch token details from contract

### DIFF
--- a/Lexplorer/Pages/PairsDetail.razor
+++ b/Lexplorer/Pages/PairsDetail.razor
@@ -152,6 +152,8 @@
                 async () => await LoopringGraphQLService.GetPair(pairId),
                 DateTimeOffset.UtcNow.AddHours(1));
             if (pair == null) return;
+            pair.token0 = await poolTokenCacheService.FetchTokenDetailsFromContract(pair.token0);
+            pair.token1 = await poolTokenCacheService.FetchTokenDetailsFromContract(pair.token1);
             StateHasChanged();
             poolToken = await poolTokenCacheService.GetPoolToken(pair);
             StateHasChanged();

--- a/Shared/Services/EthereumService.cs
+++ b/Shared/Services/EthereumService.cs
@@ -10,6 +10,7 @@ namespace Lexplorer.Services
     public class EthereumService
     {
         public const string CF_NFTTokenAddress = "0xB25f6D711aEbf954fb0265A3b29F7b9Beba7E55d";
+        private Web3 web3 = new("https://mainnet.infura.io/v3/53173af3389645d18c3bcac2ee9a751c");
 
         public async Task<string?> GetMetadataLink(string? tokenId, string? tokenAddress, int? nftType)
         {
@@ -26,8 +27,6 @@ namespace Lexplorer.Services
 
         public async Task<string?> GetMetadataLink(string? tokenId, string? tokenAddress, string? contractABI, string? functionName)
         {
-
-            var web3 = new Web3("https://mainnet.infura.io/v3/53173af3389645d18c3bcac2ee9a751c");
             try
             {
                 var contract = web3.Eth.GetContract(contractABI, tokenAddress);
@@ -46,7 +45,6 @@ namespace Lexplorer.Services
         public async Task<string?> GetEthAddressFromEns(string? ens)
         {
 
-            var web3 = new Web3("https://mainnet.infura.io/v3/53173af3389645d18c3bcac2ee9a751c");
             var ensService = new ENSService(web3);
            
             try

--- a/Shared/Services/EthereumService.cs
+++ b/Shared/Services/EthereumService.cs
@@ -57,5 +57,39 @@ namespace Lexplorer.Services
                 return null;
             }
         }
+
+        public async Task<string?> GetTokenNameFromAddress(string address)
+        {
+            try
+            {
+                const string abi = "function name() public view returns (string)";
+                var tokenContract = web3.Eth.GetContract(abi, address);
+                var function = tokenContract.GetFunction("name");
+                var name = await function.CallAsync<string>();
+                return name;
+            }
+            catch (Exception e)
+            {
+                Trace.WriteLine(e.StackTrace + "\n" + e.Message);
+                return null;
+            }
+        }
+
+        public async Task<string?> GetTokenSymbolFromAddress(string address)
+        {
+            try
+            {
+                const string abi = "function symbol() public view returns (string)";
+                var tokenContract = web3.Eth.GetContract(abi, address);
+                var function = tokenContract.GetFunction("symbol");
+                var name = await function.CallAsync<string>();
+                return name;
+            }
+            catch (Exception e)
+            {
+                Trace.WriteLine(e.StackTrace + "\n" + e.Message);
+                return null;
+            }
+        }
     }
 }

--- a/Shared/Services/EthereumService.cs
+++ b/Shared/Services/EthereumService.cs
@@ -65,8 +65,18 @@ namespace Lexplorer.Services
                 const string abi = "function name() public view returns (string)";
                 var tokenContract = web3.Eth.GetContract(abi, address);
                 var function = tokenContract.GetFunction("name");
-                var name = await function.CallAsync<string>();
-                return name;
+                string tokenName = "";
+                try
+                {
+                    tokenName = await function.CallAsync<string>();
+                }
+                catch (Exception)
+                {
+                    //try alternative ABI returning bytes32?! See maker token
+                    var tempResBytes = await function.CallRawAsync(function.CreateCallInput());
+                    tokenName = System.Text.Encoding.ASCII.GetString(tempResBytes).TrimEnd((Char)0);
+                }
+                return tokenName;
             }
             catch (Exception e)
             {
@@ -82,8 +92,19 @@ namespace Lexplorer.Services
                 const string abi = "function symbol() public view returns (string)";
                 var tokenContract = web3.Eth.GetContract(abi, address);
                 var function = tokenContract.GetFunction("symbol");
-                var name = await function.CallAsync<string>();
-                return name;
+                string tokenSymbol = "";
+                try
+                {
+                    tokenSymbol = await function.CallAsync<string>();
+                }
+                catch (Exception)
+                {
+                    //try alternative ABI returning bytes32?! See maker token
+                    var tempResBytes = await function.CallRawAsync(function.CreateCallInput());
+                    tokenSymbol = System.Text.Encoding.ASCII.GetString(tempResBytes).TrimEnd((Char)0);
+                }
+
+                return tokenSymbol;
             }
             catch (Exception e)
             {

--- a/Shared/Services/LoopringPoolTokenCacheService.cs
+++ b/Shared/Services/LoopringPoolTokenCacheService.cs
@@ -95,7 +95,7 @@ namespace Lexplorer.Services
             return poolToken;
         }
 
-        private async Task<LoopringPoolToken?> GetPoolTokenFromContract(Token token)
+        private async Task<LoopringPoolToken?> GetPoolTokenFromContract(Token token, Pool? tokenPool = default, Pair? tokenPair = default)
         {
             //no chance to get pool token via graph, so ask the contract if we have the address
             if (token.address == null) return null;
@@ -114,6 +114,8 @@ namespace Lexplorer.Services
 
             var poolToken = new LoopringPoolToken();
             poolToken.token = token;
+            poolToken.pool = tokenPool;
+            poolToken.pair = tokenPair;
             AddCachedPoolToken(poolToken, false);
             return poolToken;
         }
@@ -159,7 +161,7 @@ namespace Lexplorer.Services
                     pool.balances = await _loopringService.GetAccountBalance(pool.id, cancellationToken);
                 foreach (var balance in pool.balances!)
                 {
-                    token = await GetPoolTokenFromContract(balance.token!);
+                    token = await GetPoolTokenFromContract(balance.token!, pool);
                     if (token != null) return token;
                 }
             }

--- a/xUnitTests/EthereumServiceTests/BaseEthereumTests.cs
+++ b/xUnitTests/EthereumServiceTests/BaseEthereumTests.cs
@@ -2,7 +2,7 @@
 using Lexplorer.Services;
 using Xunit;
 
-namespace xUnitTests.NFTMetaDataTests
+namespace xUnitTests.EthereumServiceTests
 {
     //shared context for several xUnit test classes
     //https://xunit.net/docs/shared-context

--- a/xUnitTests/EthereumServiceTests/TestEthereumService.cs
+++ b/xUnitTests/EthereumServiceTests/TestEthereumService.cs
@@ -28,12 +28,39 @@ namespace xUnitTests.EthereumServiceTests
         }
 
         [Theory]
-        [InlineData("0x69a8bdEE1af2138C58B1261373B37071850689C0", "AMM-MKR-ETH", "LP-MKR-ETH")]
+        [InlineData("0xbbbbca6a901c926f240b89eacb641d8aec7aeafd", "LoopringCoin V2", "LRC")]
+        [InlineData("0x6b175474e89094c44da98b954eedeac495271d0f", "Dai Stablecoin", "DAI")]
+        [InlineData("0xff20817765cb7f73d4bde2e66e067e58d11095c2", "Amp", "AMP")]
+
+        //MKR token symbol/name is non-compliant with bytes32 return values, now supported with fallback
         [InlineData("0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2", "Maker", "MKR")]
+
+        //pool tokens not working on graph/lexplorer
+        [InlineData("0x69a8bdEE1af2138C58B1261373B37071850689C0", "AMM-MKR-ETH", "LP-MKR-ETH")] //pool 57, token 154
+        [InlineData("0xc418a3af58d7a1bad0b709fe58d0afddf64e178d", "AMM-NEC-ETH", "LP-NEC-ETH")] //token 172
+        [InlineData("0xa573c5d473702286f0ac84592eda49ad799ebaa1", "AMM-USDT-ETH", "LP-USDT-ETH")] //pool #2 token 84
+        [InlineData("0x6d537764355bc23d4eadba7829048dac8215a73c", "AMM-ETH-USDT", "LP-ETH-USDT")] //pool #3, token 85
+        [InlineData("0x4f23ca1cc6253dc1ba69a07a892d68f3b777c407", "AMM-BADGER-ETH", "LP-BADGER-ETH")] //pool #84, token 193
+        [InlineData("0x8572b8a876f47d70128c73bfca049ce00eb77563", "AMM-MASK-ETH", "LP-MASK-ETH")] //pool #86, token 195
+        [InlineData("0x4facf65a157678e62f84389dd248d99f828403d6", "AMM-0xBTC-ETH", "LP-0xBTC-ETH")] //pool #96, token 214
+        [InlineData("0x18a1a6f47fd92185b91edc322d1954349ad0b652", "AMM-ALCX-ETH", "LP-ALCX-ETH")] //pool #100, token 222
+        [InlineData("0xa186e201225e468218d53f3f9b42012022d425f3", "AMM-renDOGE-ETH", "LP-renDOGE-ETH")] //pool #106, token 233
+        [InlineData("0xb8108988406db7c4035bcfef2bd924a9810ae7e6", "AMM-BTC2XFLI-ETH", "LP-BTC2XFLI-ETH")] //pool #110 token 241
+        [InlineData("0x8195be4e48d3a2f80692fe1dba9b23b8050fb1f9", "AMM-SENT-USDC", "LP-SENT-USDC")] //pool #114, token 246
+        //0x8f871ac37fa7f575e9b8c285b38f0bf99d3c087f token 163, pool #66
+        //0xa2acf6b0304a808147ee3b10601e452c3f1bfde7 token 152, pool #55
+        //0xa738de0f4b1f52cc8410d6e49ab6ed1ca3fe1420 token 148, pool #51
+        //0xfb64c2d72e1caa0286899be8e4f88266c4d8ab9f token 146, pool #50
+        //0x8303f865a2a221c920e9fcbf2e84703991f16251 token 142, pool #46
+        //0xba64cdf65aea36ff4a58dcf288f1a62923555795 token 135, pool #39
+        //0x22844c482b0626ac09b5689b4d8e81fe6710f5f4 token 131, pool #35
+        //0xe8ea36f850db564408e4165a92bccb4e6e5f5e20 token 129, pool #33
+        //0x9387e06961988726dd0732b6930be1c0a5343901 token 128, pool #32
+
         public async void TestGetTokenInfo(string contract, string expectedName, string expectedSymbol)
         {
             var name = await fixture.EthS.GetTokenNameFromAddress(contract);
-            //Assert.Equal(expectedName, name);
+            Assert.Equal(expectedName, name);
             var symbol = await fixture.EthS.GetTokenSymbolFromAddress(contract);
             Assert.Equal(expectedSymbol, symbol);
         }

--- a/xUnitTests/EthereumServiceTests/TestEthereumService.cs
+++ b/xUnitTests/EthereumServiceTests/TestEthereumService.cs
@@ -26,5 +26,16 @@ namespace xUnitTests.EthereumServiceTests
             var hexAddress = await fixture.EthS.GetEthAddressFromEns(ens);
             Assert.NotNull(hexAddress);
         }
+
+        [Theory]
+        [InlineData("0x69a8bdEE1af2138C58B1261373B37071850689C0", "AMM-MKR-ETH", "LP-MKR-ETH")]
+        [InlineData("0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2", "Maker", "MKR")]
+        public async void TestGetTokenInfo(string contract, string expectedName, string expectedSymbol)
+        {
+            var name = await fixture.EthS.GetTokenNameFromAddress(contract);
+            //Assert.Equal(expectedName, name);
+            var symbol = await fixture.EthS.GetTokenSymbolFromAddress(contract);
+            Assert.Equal(expectedSymbol, symbol);
+        }
     }
 }

--- a/xUnitTests/EthereumServiceTests/TestEthereumService.cs
+++ b/xUnitTests/EthereumServiceTests/TestEthereumService.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace xUnitTests.NFTMetaDataTests
+namespace xUnitTests.EthereumServiceTests
 {
     [Collection("EthereumTests collection")]
     public class TestEthereumService

--- a/xUnitTests/PoolTokenTests/BasePTTest.cs
+++ b/xUnitTests/PoolTokenTests/BasePTTest.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Lexplorer.Services;
+
+namespace xUnitTests.PoolTokenTests
+{
+    //shared context for several xUnit test classes
+    //https://xunit.net/docs/shared-context
+    public class PoolTokensTestsFixture : IDisposable
+    {
+        public LoopringGraphQLService LGS { get; private set; }
+        public EthereumService ES { get; private set; }
+        public LoopringPoolTokenCacheService LPTCS { get; private set; }
+
+        public PoolTokensTestsFixture()
+        {
+            LGS = new LoopringGraphQLService("https://api.thegraph.com/subgraphs/name/juanmardefago/loopring36");
+            ES = new EthereumService();
+            LPTCS = new LoopringPoolTokenCacheService(LGS, ES);
+            LPTCS.DisableCache();
+        }
+
+        public void Dispose()
+        {
+            LGS.Dispose();
+            GC.SuppressFinalize(this);
+        }
+    }
+
+    [CollectionDefinition("PoolTokens collection")]
+    public class PoolTokensCollection : ICollectionFixture<PoolTokensTestsFixture>
+    {
+        // This class has no code, and is never created. Its purpose is simply
+        // to be the place to apply [CollectionDefinition] and all the
+        // ICollectionFixture<> interfaces.
+    }
+
+}

--- a/xUnitTests/PoolTokenTests/TestPoolTokensByContract.cs
+++ b/xUnitTests/PoolTokenTests/TestPoolTokensByContract.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using Xunit;
+using Lexplorer.Models;
+
+namespace xUnitTests.PoolTokenTests
+{
+    [Collection("PoolTokens collection")]
+    public class TestPoolTokensByContract
+	{
+        readonly PoolTokensTestsFixture fixture;
+
+        public TestPoolTokensByContract(PoolTokensTestsFixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        [Theory]
+        [InlineData("84", "0xa573c5d473702286f0ac84592eda49ad799ebaa1", "LP-USDT-ETH")]
+        [InlineData("85", "0x6d537764355bc23d4eadba7829048dac8215a73c", "LP-ETH-USDT")]
+        [InlineData("86", "0x605872a5a459e778959b8a49dc3a56a8c9197983", "LP-ETH-USDT")]
+        public async void TestPoolTokenByToken(string tokenID, string tokenAddress, string expectedSymbol)
+        {
+            var token = new Token();
+            token.id = tokenID;
+            token.address = tokenAddress;
+            var poolToken = await fixture.LPTCS.GetPoolToken(token);
+
+            Assert.NotNull(poolToken);
+            Assert.NotNull(poolToken!.token);
+            Assert.Equal(expectedSymbol, poolToken!.token!.symbol);
+        }
+
+        [Theory]
+        [InlineData("2", "84", "LP-USDT-ETH")]
+        [InlineData("3", "85", "LP-ETH-USDT")]
+        [InlineData("4", "86", "LP-ETH-USDT")]
+        public async void TestPoolTokenByPool(string poolID, string expectedTokenID, string expectedSymbol)
+        {
+            var pool = new Pool();
+            pool.id = poolID;
+            var poolToken = await fixture.LPTCS.GetPoolToken(pool);
+
+            Assert.NotNull(poolToken);
+            Assert.NotNull(poolToken!.token);
+            Assert.Equal(expectedTokenID, poolToken!.token!.id);
+            Assert.Equal(expectedSymbol, poolToken!.token!.symbol);
+        }
+
+        //cannot test same token 84 with a TestPoolTokenByPair as no pair for USDT-ETH exists
+        //there is a pair the other way around but pair 0-3 actually has two pools!
+        //pool 4, token 86 and abandoned pool 3, token 85!
+        //since we're searching via swaps, we don't get the old pool token
+
+        [Theory]
+        [InlineData("85", "0x6d537764355bc23d4eadba7829048dac8215a73c", "3", "LP-ETH-USDT")]
+        public async void TestDuplicatePoolToken(string tokenID, string tokenAddress, string poolID, string expectedSymbol)
+        {
+            //enable caching to actually try to add same token first directly, then via pool
+            fixture.LPTCS.EnableCache();
+
+            var token = new Token();
+            token.id = tokenID;
+            token.address = tokenAddress;
+            var poolTokenDirect = await fixture.LPTCS.GetPoolToken(token);
+            Assert.NotNull(poolTokenDirect);
+            Assert.NotNull(poolTokenDirect!.token);
+            Assert.Equal(tokenID, poolTokenDirect!.token!.id);
+            Assert.Equal(expectedSymbol, poolTokenDirect!.token!.symbol);
+
+            var pool = new Pool();
+            pool.id = poolID;
+            var poolTokenViaPool = await fixture.LPTCS.GetPoolToken(pool);
+
+            Assert.NotNull(poolTokenViaPool);
+            Assert.NotNull(poolTokenViaPool!.token);
+            Assert.Equal(tokenID, poolTokenViaPool!.token!.id);
+            Assert.Equal(expectedSymbol, poolTokenViaPool!.token!.symbol);
+            fixture.LPTCS.DisableCache();
+        }
+
+    }
+}
+

--- a/xUnitTests/PoolTokenTests/TestPoolTokensByContract.cs
+++ b/xUnitTests/PoolTokenTests/TestPoolTokensByContract.cs
@@ -75,6 +75,10 @@ namespace xUnitTests.PoolTokenTests
             Assert.NotNull(poolTokenViaPool!.token);
             Assert.Equal(tokenID, poolTokenViaPool!.token!.id);
             Assert.Equal(expectedSymbol, poolTokenViaPool!.token!.symbol);
+
+            Assert.NotNull(poolTokenViaPool.pool);
+            Assert.Equal(poolID, poolTokenViaPool.pool!.id);
+
             fixture.LPTCS.DisableCache();
         }
 

--- a/xUnitTests/PoolTokenTests/TestPoolTokensByGraphQL.cs
+++ b/xUnitTests/PoolTokenTests/TestPoolTokensByGraphQL.cs
@@ -50,6 +50,7 @@ namespace xUnitTests.PoolTokenTests
 
         [Theory]
         [InlineData("0-1", "0", "ETH", "1", "LRC", "LP-ETH-LRC")]
+        [InlineData("0-3", "0", "ETH", "3", "USDT", "LP-ETH-USDT")]
         public async void TestPoolTokenByPair(string pairID, string tokenID0, string tokenSymbol0, string tokenID1, string tokenSymbol1, string expectedSymbol)
         {
             var pair = new Pair();

--- a/xUnitTests/PoolTokenTests/TestPoolTokensByGraphQL.cs
+++ b/xUnitTests/PoolTokenTests/TestPoolTokensByGraphQL.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using Xunit;
+using Lexplorer.Models;
+
+namespace xUnitTests.PoolTokenTests
+{
+    [Collection("PoolTokens collection")]
+    public class TestPoolTokensByGraphQL
+	{
+        readonly PoolTokensTestsFixture fixture;
+
+        public TestPoolTokensByGraphQL(PoolTokensTestsFixture fixture)
+		{
+            this.fixture = fixture;
+		}
+
+        private static Token TokenCreationHelper(string id, string symbol)
+        {
+            var token = new Token();
+            token.id = id;
+            token.symbol = symbol;
+            return token;
+        }
+
+        [Theory]
+        [InlineData("83", "LP-ETH-LRC")]
+        public async void TestPoolTokenByToken(string tokenID, string expectedSymbol)
+        {
+            var token = new Token();
+            token.id = tokenID;
+            var poolToken = await fixture.LPTCS.GetPoolToken(token);
+
+            Assert.NotNull(poolToken);
+            Assert.NotNull(poolToken!.token);
+            Assert.Equal(expectedSymbol, poolToken!.token!.symbol);
+        }
+
+        [Theory]
+        [InlineData("1", "LP-ETH-LRC")]
+        public async void TestPoolTokenByPool(string poolID, string expectedSymbol)
+        {
+            var pool = new Pool();
+            pool.id = poolID;
+            var poolToken = await fixture.LPTCS.GetPoolToken(pool);
+
+            Assert.NotNull(poolToken);
+            Assert.NotNull(poolToken!.token);
+            Assert.Equal(expectedSymbol, poolToken!.token!.symbol);
+        }
+
+        [Theory]
+        [InlineData("0-1", "0", "ETH", "1", "LRC", "LP-ETH-LRC")]
+        public async void TestPoolTokenByPair(string pairID, string tokenID0, string tokenSymbol0, string tokenID1, string tokenSymbol1, string expectedSymbol)
+        {
+            var pair = new Pair();
+            pair.id = pairID;
+            pair.token0 = TokenCreationHelper(tokenID0, tokenSymbol0);
+            pair.token1 = TokenCreationHelper(tokenID1, tokenSymbol1);
+            var poolToken = await fixture.LPTCS.GetPoolToken(pair);
+
+            Assert.NotNull(poolToken);
+            Assert.NotNull(poolToken!.token);
+            Assert.Equal(expectedSymbol, poolToken!.token!.symbol);
+        }
+
+        [Theory]
+        [InlineData("25279-252", "LP-ETH-LRC")]
+        public async void TestPoolTokenBySwap(string swapID, string expectedSymbol)
+        {
+            var swap = new Swap();
+            swap.id = swapID;
+            var poolToken = await fixture.LPTCS.GetPoolToken(swap);
+
+            Assert.NotNull(poolToken);
+            Assert.NotNull(poolToken!.token);
+            Assert.Equal(expectedSymbol, poolToken!.token!.symbol);
+        }
+    }
+}
+

--- a/xUnitTests/xUnitTests.csproj
+++ b/xUnitTests/xUnitTests.csproj
@@ -28,6 +28,10 @@
 
   <ItemGroup>
     <None Remove="NFTMetaDataTests\" />
+    <None Remove="PoolTokenTests\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="PoolTokenTests\" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 


### PR DESCRIPTION
Fixing #217 and a bunch of related issues with AMM/LP tokens.

Before:
![](https://user-images.githubusercontent.com/44807458/177176806-62972be7-156c-4b6e-9b5f-5a91e0bac60d.png)

After:
<img width="874" alt="image" src="https://user-images.githubusercontent.com/44807458/179417750-ef43093b-1622-4777-9cf3-1cb5af55a630.png">

1. If a token has an empty name, name and symbol are fetched from the L1 contract.
2. Fallback for non-ERC20-compliant maker token: if function returning string fails, try again with CallRawAsync and convert from ASCII to string.
3. Lots of new tests for PoolTokenService