### PR TITLE
Searching for token symbol

### DIFF
--- a/Shared/Models/LoopringV3.cs
+++ b/Shared/Models/LoopringV3.cs
@@ -123,6 +123,8 @@ namespace Lexplorer.Models
         public string? address { get; set; }
         public int decimals { get; set; }
         public string? id { get; set; }
+        [JsonProperty("__typename")]
+        public string? typeName { get; set; }
         public string? name { get; set; }
         public string? symbol { get; set; }
         public double tradedVolume { get; set; }

--- a/Shared/Services/LoopringGraphQLService.cs
+++ b/Shared/Services/LoopringGraphQLService.cs
@@ -1006,6 +1006,7 @@ namespace Lexplorer.Services
                 { "transactions", typeof(Transaction) },
                 { "nonFungibleTokens", typeof(NonFungibleToken) },
                 { "nonFungibleTokensBynftID", typeof(NonFungibleToken) },
+                { "tokens", typeof(Token) },
         };
         public async Task<IList<object>?> Search(string searchTerm)
         {
@@ -1052,6 +1053,13 @@ namespace Lexplorer.Services
                   id
                   __typename
                   nftID
+                }
+                tokens(where: {symbol_contains_nocase: $searchTerm}
+                ) {
+                  id
+                  __typename
+                  symbol
+                  name
                 }
               }
             ";

--- a/xUnitTests/LoopringGraphTests/TestSearch.cs
+++ b/xUnitTests/LoopringGraphTests/TestSearch.cs
@@ -75,5 +75,17 @@ namespace xUnitTests.LoopringGraphTests
             if (!skipContainsID)
                 Assert.Contains(nftid, (searchResult![0] as NonFungibleToken)!.id, StringComparison.InvariantCultureIgnoreCase);
         }
+
+        [Theory]
+        [InlineData("LRC")]
+        [InlineData("eth")]
+        public async void SearchToken(string tokenSymbol)
+        {
+            var searchResult = await service.Search(tokenSymbol);
+            Assert.NotEmpty(searchResult);
+            Assert.IsType<Token>(searchResult![0]);
+            Assert.Contains(tokenSymbol, (searchResult![0] as Token)!.symbol, StringComparison.InvariantCultureIgnoreCase);
+        }
+
     }
 }


### PR DESCRIPTION
Fixing  #222

* intentionally searching case insensitive and with contains
* added missing typename property to token, here it was only necessary
  for the search results to list the proper search result type
* added basic test, for LRC specifically and eth for a whole set of
  search results