### PR TITLE
New ENSCacheService for ENS lookup and reverse lookup

### DIFF
--- a/Lexplorer/Components/ENSList.razor
+++ b/Lexplorer/Components/ENSList.razor
@@ -1,0 +1,19 @@
+﻿@if (ensDomains != null)
+    @foreach (string domain in ensDomains.Keys)
+    {
+        @if (ensDomains[domain] == ENS.SourceType.Lookup)
+        {
+            <MudIcon Icon="@Icons.Filled.Search" Title="Lookup" Size="Size.Small" Style="vertical-align:middle" />
+        }
+        @if (ensDomains[domain] == ENS.SourceType.ReverseLookup)
+        {
+            <MudIcon Icon="@Icons.Filled.YoutubeSearchedFor" Title="Reverse Lookup" Size="Size.Small" Style="vertical-align:middle" />
+        }
+        @domain
+        <br />
+    }
+
+@code {
+    [Parameter]
+    public Dictionary<string, ENS.SourceType>? ensDomains { get; set; }
+}

--- a/Lexplorer/Pages/AccountDetails.razor
+++ b/Lexplorer/Pages/AccountDetails.razor
@@ -7,6 +7,9 @@
 @inject NavigationManager NavigationManager;
 @inject IDialogService DialogService;
 @inject IAppCache AppCache;
+@inject ENSCacheService ENSCacheService;
+
+@using DomainsDictionary = Dictionary<string, Lexplorer.Models.ENS.SourceType>;
 
 <PageTitle>The Lexplorer - Account</PageTitle>
 <MudContainer Fixed="true" Class="px-0 extra-extra-extra-large">
@@ -38,6 +41,15 @@
                     <td>0x@((account as User)!.publicKey)</td>
                 </tr>
 
+            }
+            @if (ensDomains != null)
+            {
+                <tr>
+                    <td>ENS names</td>
+                    <td>
+                        <ENSList ensDomains="@ensDomains" />
+                    </td>
+                </tr>
             }
             @if (poolToken != null)
             {
@@ -166,6 +178,7 @@
 
     private Account? account { get; set; }
     private LoopringPoolToken? poolToken { get; set; }
+    private DomainsDictionary? ensDomains { get; set; }
     private IList<Transaction>? transactions { get; set; } = new List<Transaction>();
     private IList<AccountNFTSlot>? accountNFTSlots { get; set; }
     private CancellationTokenSource? cts;
@@ -187,6 +200,7 @@
                 if (account != null && account.id != accountId)
                 {
                     account = null;
+                    ensDomains = null;
                     transactions = new List<Transaction>();
                     accountNFTSlots = null;
                     pageNumber = "1";
@@ -220,6 +234,10 @@
                                 balance.token = poolToken.token;
                         }
                     balancesLoading = false;
+                    StateHasChanged();
+
+                    ensDomains = await ENSCacheService.ReverseLookupAddress(account.address, localCTS.Token);
+                    localCTS.Token.ThrowIfCancellationRequested();
                     StateHasChanged();
                 }
                 if (string.IsNullOrEmpty(pageNumber))
@@ -258,7 +276,7 @@
                 Trace.WriteLine(e.StackTrace + "\n" + e.Message);
             }
             finally
-            { 
+            {
                 //now for cleanup, we must clear cts, but only if it is still our localCTS, which we're about to dispose
                 //otherwise a new call has already replaced cts with it's own localCTS
                 Interlocked.CompareExchange<CancellationTokenSource?>(ref cts, null, localCTS);

--- a/Lexplorer/Pages/TokenDetails.razor
+++ b/Lexplorer/Pages/TokenDetails.razor
@@ -8,6 +8,10 @@
 @inject LoopringGraphQLService LoopringGraphQLService;
 @inject LoopringPoolTokenCacheService poolTokenCacheService;
 @inject UniswapGraphQLService UniswapGraphQLService;
+@inject ENSCacheService ENSCacheService;
+
+@using DomainsDictionary = Dictionary<string, Lexplorer.Models.ENS.SourceType>;
+@using AddressDomainsDictionary = Dictionary<string, Dictionary<string, Lexplorer.Models.ENS.SourceType>>;
 
 <PageTitle>The Lexplorer - token @(token?.failSafeSymbol) </PageTitle>
 
@@ -57,12 +61,14 @@
     <HeaderContent>
         <MudTh>Account Id</MudTh>
         <MudTh>L1 address</MudTh>
+        <MudTh>ENS</MudTh>
         <MudTh>Type</MudTh>
         <MudTh Style="text-align:right">Balance</MudTh>
     </HeaderContent>
     <RowTemplate>
         <MudTd DataLabel="Account Id">@LinkHelper.GetObjectLink(context?.account)</MudTd>
         <MudTd DataLabel="Address"><L1AccountLink address="@context?.account?.address" /></MudTd>
+        <MudTd DataLabel="ENS"><ENSList ensDomains="@GetENS(context?.account?.address)" /></MudTd>
         <MudTd DataLabel="Type">@context?.account?.typeName</MudTd>
         <MudTd Style="text-align:right" DataLabel="Balance">@TokenAmountConverter.ToStringWithExponent(context.balance, token?.decimals ?? 0, 1)</MudTd>
     </RowTemplate>
@@ -92,54 +98,99 @@
         }
     }
 
+    private DomainsDictionary? GetENS(string? address)
+    {
+        DomainsDictionary? retValue = null;
+        if (address != null)
+            ensDictionary?.TryGetValue(address, out retValue);
+        return retValue;
+    }
+
     private Token? token { get; set; }
     private LoopringPoolToken? poolToken { get; set; }
     private UniswapToken? uniswapToken { get; set; }
     private IList<AccountTokenBalance>? tokenHolders { get; set; } = new List<AccountTokenBalance>();
+    private AddressDomainsDictionary? ensDictionary { get; set; }
     public readonly int pageSize = 25;
     bool isLoading = true;
+    private CancellationTokenSource? cts = null;
 
     protected override async Task OnParametersSetAsync()
     {
-        if (token?.id != tokenId)
+        //cancel any previous OnParametersSetAsync which might still be running
+        cts?.Cancel();
+
+        using (CancellationTokenSource localCTS = new CancellationTokenSource())
         {
-            isLoading = true;
-            poolToken = null;
-            uniswapToken = null;
-            tokenHolders = new List<AccountTokenBalance>();
-            string tokenCacheKey = $"token-{tokenId}";
-            token = await AppCache.GetOrAddAsyncNonNull(tokenCacheKey,
-                async () => await LoopringGraphQLService.GetToken(tokenId),
-                DateTimeOffset.UtcNow.AddHours(1));
-            if (token == null) return;
-            StateHasChanged();
-            poolToken = await poolTokenCacheService.GetPoolToken(token);
-            if (poolToken?.token == null)
+            //give future calls a chance to cancel us; it is now safe to replace
+            //any previous value of cts, since we already cancelled it above
+            Interlocked.Exchange<CancellationTokenSource?>(ref cts, localCTS);
+            try
             {
-                if (token.id != "0")  //we cannot get the ETH price that way, ETH has no token address
-                { 
-                    string uniswapTokenCacheKey = $"uniSwapTokenPrice-{token.address}";
-                    uniswapToken = await AppCache.GetOrAddAsyncNonNull(uniswapTokenCacheKey,
-                        async () => await UniswapGraphQLService.GetTokenPrice(token.address!),
+                if (token?.id != tokenId)
+                {
+                    isLoading = true;
+                    poolToken = null;
+                    uniswapToken = null;
+                    tokenHolders = new List<AccountTokenBalance>();
+                    ensDictionary = null;
+                    string tokenCacheKey = $"token-{tokenId}";
+                    token = await AppCache.GetOrAddAsyncNonNull(tokenCacheKey,
+                        async () => await LoopringGraphQLService.GetToken(tokenId),
                         DateTimeOffset.UtcNow.AddHours(1));
+                    if (token == null) return;
+                    StateHasChanged();
+                    poolToken = await poolTokenCacheService.GetPoolToken(token);
+                    if (poolToken?.token == null)
+                    {
+                        if (token.id != "0")  //we cannot get the ETH price that way, ETH has no token address
+                        {
+                            string uniswapTokenCacheKey = $"uniSwapTokenPrice-{token.address}";
+                            uniswapToken = await AppCache.GetOrAddAsyncNonNull(uniswapTokenCacheKey,
+                                async () => await UniswapGraphQLService.GetTokenPrice(token.address!),
+                                DateTimeOffset.UtcNow.AddHours(1));
+                        }
+                    }
+                    else
+                    {
+                        //normally we would just replace the token with poolToken.token, but currently that would loose tradedVolume
+                        token.name = poolToken.token.name;
+                        token.symbol = poolToken.token.symbol;
+                        token.decimals = poolToken.token.decimals;
+                        StateHasChanged();
+                    }
+                }
+
+                isLoading = true;
+                string tokenHoldersCacheKey = $"tokenHolders-{tokenId}-{gotoPage}";
+                tokenHolders = await AppCache.GetOrAddAsyncNonNull(tokenHoldersCacheKey,
+                    async () => await LoopringGraphQLService.GetTokenHolders(token.id!, (gotoPage - 1) * pageSize, pageSize, cancellationToken: localCTS.Token),
+                    DateTimeOffset.UtcNow.AddHours(1));
+                localCTS.Token.ThrowIfCancellationRequested();
+
+                List<string>? addressList = tokenHolders?.Select(x => x?.account?.address).OfType<string>().ToList();
+
+                ensDictionary = ENSCacheService.GetCachedENS(ref addressList);
+                if ((addressList?.Count ?? 0) > 0)
+                {
+                    StateHasChanged();
+                    ensDictionary = await ENSCacheService.ReverseLookupAddressList(addressList, ensDictionary, localCTS.Token);
                 }
             }
-            else
+            catch (OperationCanceledException)
             {
-                //normally we would just replace the token with poolToken.token, but currently that would loose tradedVolume
-                token.name = poolToken.token.name;
-                token.symbol = poolToken.token.symbol;
-                token.decimals = poolToken.token.decimals;
-                StateHasChanged();
+            }
+            catch (Exception e)
+            {
+                Trace.WriteLine(e.StackTrace + "\n" + e.Message);
+            }
+            finally
+            {
+                //now for cleanup, we must clear cts, but only if it is still our localCTS, which we're about to dispose
+                //otherwise a new call has already replaced cts with it's own localCTS
+                Interlocked.CompareExchange<CancellationTokenSource?>(ref cts, null, localCTS);
             }
         }
-
-        isLoading = true;
-        string tokenHoldersCacheKey = $"tokenHolders-{tokenId}-{gotoPage}";
-        tokenHolders = await AppCache.GetOrAddAsyncNonNull(tokenHoldersCacheKey,
-            async () => await LoopringGraphQLService.GetTokenHolders(token.id!, (gotoPage - 1) * pageSize, pageSize),
-            DateTimeOffset.UtcNow.AddHours(1));
         isLoading = false;
-        StateHasChanged();
     }
 }

--- a/Lexplorer/Program.cs
+++ b/Lexplorer/Program.cs
@@ -17,6 +17,7 @@ builder.Services.AddSingleton<EthereumService>();
 builder.Services.AddSingleton<NftMetadataService>();
 builder.Services.AddSingleton<ILoopStatsService, LoopStatsService>();
 builder.Services.AddSingleton<LoopringPoolTokenCacheService>();
+builder.Services.AddSingleton<ENSCacheService>();
 builder.Services.AddLazyCache();
 
 //registration of CSV export formats, no automatic registration possible

--- a/Lexplorer/Shared/MainLayout.razor
+++ b/Lexplorer/Shared/MainLayout.razor
@@ -1,9 +1,10 @@
 ﻿@inherits LayoutComponentBase
-@inject LoopringGraphQLService LoopringGraphQLService;
-@inject NavigationManager NavigationManager;
-@inject EthereumService EthereumService;
-@inject IJSRuntime JS;
+@inject LoopringGraphQLService LoopringGraphQLService
+@inject NavigationManager NavigationManager
+@inject EthereumService EthereumService
+@inject IJSRuntime JS
 @inject IDialogService DialogService
+@inject ENSCacheService ENSCacheService
 
 <MudThemeProvider @bind-IsDarkMode="@_isDarkMode" Theme="_theme" />
 <MudDialogProvider />
@@ -111,6 +112,7 @@
                 StateHasChanged();
                 return;
             }
+            ENSCacheService.AddLookupAddress(searchTerm, hexAddress);
             _searchTerm = hexAddress; //carry on searching with the found address
         }
 
@@ -127,10 +129,10 @@
 
     async Task DialogSearch()
     {
-        DialogOptions maxWidth = new DialogOptions() 
-        { 
-            MaxWidth = MaxWidth.Medium, 
-            FullWidth = true, 
+        DialogOptions maxWidth = new DialogOptions()
+        {
+            MaxWidth = MaxWidth.Medium,
+            FullWidth = true,
             Position = DialogPosition.TopCenter,
             CloseButton = true
         };

--- a/Lexplorer/appsettings.json
+++ b/Lexplorer/appsettings.json
@@ -15,6 +15,9 @@
     },
     "loopringgraph": {
       "endpoint": "https://api.thegraph.com/subgraphs/name/juanmardefago/loopring36"
+    },
+    "ENSGraph": {
+      "endpoint": "https://api.thegraph.com/subgraphs/name/ensdomains/ens"
     }
   },
   "AllowedHosts": "*"

--- a/Shared/Models/ENS.cs
+++ b/Shared/Models/ENS.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Lexplorer.Models
+{
+    public class ENS
+	{
+        public class Domain
+        {
+            public string? id { get; set; }
+            public string? name { get; set; }
+            public string? labelName { get; set; }
+            public string? labelHash { get; set; }
+            public Account? resolvedAddress { get; set; }
+        }
+
+        public class Account
+        {
+            public string? id { get; set; }
+            public List<Domain>? domains { get; set; }
+        }
+
+        public enum SourceType
+        {
+            Lookup,
+            ReverseLookup
+        }
+
+    }
+}

--- a/Shared/Services/ENSCacheService.cs
+++ b/Shared/Services/ENSCacheService.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
+using Newtonsoft.Json.Linq;
+using RestSharp;
+using RestSharp.Serializers;
+using Microsoft.Extensions.Configuration;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Threading;
+using System.Diagnostics;
+using Lexplorer.Models;
+using System.Collections.Concurrent;
+using System.Linq;
+
+namespace Lexplorer.Services
+{
+    using DomainsDictionary = Dictionary<string, ENS.SourceType>;
+
+    public class ENSCacheService : IDisposable
+    {
+        readonly RestClient _client;
+
+        private readonly ConcurrentDictionary<string, DomainsDictionary> ensEntries = new(StringComparer.InvariantCultureIgnoreCase);
+        private readonly HashSet<string> ensAlreadyLookedUp = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
+
+        private bool disableCaching { get; set; } = false; //for tests
+        public void DisableCache() => disableCaching = true;
+        public void EnableCache()
+        {
+            disableCaching = false;
+            ensEntries.Clear();
+            ensAlreadyLookedUp.Clear();
+        }
+
+        public ENSCacheService(IConfiguration config)
+        {
+            _client = new RestClient(config.GetSection("services:ENSGraph:endpoint").Value);
+        }
+
+        public ENSCacheService(string baseUrl)
+        {
+            _client = new RestClient(baseUrl);
+        }
+
+        public void Dispose()
+        {
+            _client?.Dispose();
+            GC.SuppressFinalize(this);
+        }
+
+        private void AddDomains(string address, string[]? domainNames, ENS.SourceType sourceType)
+        {
+            if (disableCaching) return;
+            if ((domainNames?.Length ?? 0) == 0) return;
+
+            _ = ensEntries.AddOrUpdate(address,
+                domainNames!.ToDictionary(x => x, x => sourceType),
+                (key, oldvalue) =>
+                {
+                    //do not overwrite sourceType if already there
+                    foreach (string domain in domainNames!)
+                        oldvalue.TryAdd(domain, sourceType);
+                    return oldvalue;
+                });
+        }
+
+        public void AddLookupAddress(string domainName, string hexAddress)
+        {
+            AddDomains(hexAddress, new[] {domainName}, ENS.SourceType.Lookup);
+        }
+
+        public async Task<DomainsDictionary?> ReverseLookupAddress(string? address, CancellationToken cancellationToken = default)
+        {
+            if (address == null) return null;
+
+            DomainsDictionary? retValue = null;
+            if (!ensAlreadyLookedUp.Contains(address))
+            {
+                try
+                {
+                    var accounts = await ReverseLookup(new List<string>() { address }, cancellationToken);
+                    if (!disableCaching)
+                        _ = ensAlreadyLookedUp.Add(address);
+
+                    var domainList = accounts?.FirstOrDefault<ENS.Account>()?.domains;
+                    var domainNames = domainList?.Select(item => item.name).
+                        OfType<string>() //skip null values
+                        .ToArray();
+
+                    AddDomains(address, domainNames, ENS.SourceType.ReverseLookup);
+                    if ((disableCaching) && ((domainNames?.Length ?? 0) > 0))
+                        retValue = domainNames!.ToDictionary(x => x, x => ENS.SourceType.ReverseLookup);
+                }
+                catch (Exception e)
+                {
+                    Debug.WriteLine(e.ToString());
+                }
+            }
+            if (!disableCaching)
+                ensEntries.TryGetValue(address, out retValue);
+            return retValue;
+        }
+
+        public async Task<List<ENS.Account>?> ReverseLookup(IList<string> addresses, CancellationToken cancellationToken = default)
+        {
+            var revLookupQuery = @"
+            query revLookup(
+                $addresses: [String]
+            ){
+                accounts(
+                    where: {id_in: $addresses}
+                ) {
+                    id
+                    domains {
+                      id
+                      name
+                      labelName
+                      labelhash
+                      parent {
+                        id
+                      }
+                    }
+                }
+            }
+            ";
+
+            var request = new RestRequest();
+            request.AddHeader("Content-Type", "application/json");
+            request.AddJsonBody(new
+            {
+                query = revLookupQuery,
+                variables = new
+                {
+                    addresses
+                }
+            });
+            var response = await _client.PostAsync(request, cancellationToken);
+            JObject jresponse = JObject.Parse(response.Content!);
+            JToken? jtoken = jresponse["data"]!["accounts"];
+            return jtoken!.ToObject<List<ENS.Account>>()!;
+        }
+	}
+}

--- a/Shared/Shared.projitems
+++ b/Shared/Shared.projitems
@@ -29,5 +29,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Services\LoopringPoolTokenCacheService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Models\LoopringPoolToken.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\GraphQLTransactionListFragments.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Services\ENSCacheService.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Models\ENS.cs" />
   </ItemGroup>
 </Project>

--- a/xUnitTests/ENSTests/BaseENSTests.cs
+++ b/xUnitTests/ENSTests/BaseENSTests.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Lexplorer.Services;
+using Xunit;
+
+namespace xUnitTests.ENSTests
+{
+    //shared context for several xUnit test classes
+    //https://xunit.net/docs/shared-context
+    public class ENSTestsFixture
+    {
+
+        public ENSCacheService ENS { get; private set; }
+
+        public ENSTestsFixture()
+        {
+            ENS = new ENSCacheService("https://api.thegraph.com/subgraphs/name/ensdomains/ens");
+            ENS.DisableCache();
+        }
+    }
+
+    [CollectionDefinition("ENSTests collection")]
+    public class ENSCollection : ICollectionFixture<ENSTestsFixture>
+    {
+        // This class has no code, and is never created. Its purpose is simply
+        // to be the place to apply [CollectionDefinition] and all the
+        // ICollectionFixture<> interfaces.
+    }        
+	
+}

--- a/xUnitTests/ENSTests/TestENSService.cs
+++ b/xUnitTests/ENSTests/TestENSService.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace xUnitTests.ENSTests
+{
+    [Collection("ENSTests collection")]
+    public class TestENSService
+    {
+        readonly ENSTestsFixture fixture;
+
+        public TestENSService(ENSTestsFixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        [Theory]
+        [InlineData("0x36cd6b3b9329c04df55d55d41c257a5fdd387acd", "0x99fdddfdc9277404db0379009274cc98d3688f8b")]
+        public async void TestReverseLoopkup(params string[] addresses)
+        {
+            var accounts = await fixture.ENS.ReverseLookup(addresses);
+            Assert.NotEmpty(accounts);
+            Assert.Equal(addresses.Length, accounts!.Count);
+        }
+
+        [Theory]
+        [InlineData("0xaf0c3945c94f4271ded7bcdbf8762039cc36396a", "shortdestroyers.eth", "[0dcd3103d2187321948875f4b46de67bbcd107f64c1b76c1d3b6df44b2b178d7].loopring.eth")]
+        [InlineData("0xabcdef0123543451231231324235432423423423")]
+        public async void TestReverseLookupAddress(string address, params string[] domains)
+        {
+            var ens = await fixture.ENS.ReverseLookupAddress(address);
+            Assert.Equal(domains.Length, ens?.Count ?? 0);
+            if (domains.Length > 0)
+                Assert.Equal(domains, ens?.Keys.ToArray());
+        }
+
+	}
+}

--- a/xUnitTests/xUnitTests.csproj
+++ b/xUnitTests/xUnitTests.csproj
@@ -29,9 +29,11 @@
   <ItemGroup>
     <None Remove="NFTMetaDataTests\" />
     <None Remove="PoolTokenTests\" />
+    <None Remove="ENSTests\" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="PoolTokenTests\" />
+    <Folder Include="ENSTests\" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 


### PR DESCRIPTION
Closes #219 

1. Added to account details page
2. if a lookup is made during a search, the search term and the resulting address are added to the cache
3. reverse lookup is done using https://thegraph.com/hosted-service/subgraph/ensdomains/ens
4. since some *.loopring.eth ENS only store a hash instead of the labelName, they cannot be properly looked up in reverse
5. this might result in the same ENS appearing twice - hence the icons depicting the origin of the ENS: <img width="943" alt="image" src="https://user-images.githubusercontent.com/44807458/181470709-ea270e42-f52b-476f-8440-7c8579d184ab.png">
7. the correct ENS name here is only shown because I previously searched for it
8. with this approach, we're open for potentially adding the Loopring API as a 3rd source for ENS lookups
9. Reverse lookup is also possible for a list of addresses with a single ENS query
10. Added ENS names to token holders page - showing some addresses with multiple ENS names: <img width="948" alt="image" src="https://user-images.githubusercontent.com/44807458/181471720-f7ad6774-edec-4725-acc2-8c86ead0d27d.png">
