### PR TITLE
Fix NFT errors

### DIFF
--- a/Lexplorer/Pages/NFTDetail.razor
+++ b/Lexplorer/Pages/NFTDetail.razor
@@ -336,7 +336,8 @@
                         }
                         catch (Exception e)
                         {
-                            nftMetadata!.Error = String.Join(System.Environment.NewLine, nftMetadata.Error, e.Message);
+                            if ((nftMetadata!.Error == null) || (!nftMetadata!.Error!.EndsWith(e.Message)))
+                                nftMetadata!.Error = String.Join(System.Environment.NewLine, nftMetadata.Error, e.Message);
                         }
                     }
                     StateHasChanged();

--- a/Shared/Services/NftMetadataService.cs
+++ b/Shared/Services/NftMetadataService.cs
@@ -53,7 +53,7 @@ namespace Lexplorer.Services
             {
                 var fileNamePortion = modLink.Substring(idx + 1);
                 if (!Uri.IsWellFormedUriString(fileNamePortion, UriKind.Relative))
-                    fileNamePortion = Uri.EscapeDataString(fileNamePortion);
+                    fileNamePortion = Uri.EscapeDataString(Uri.UnescapeDataString(fileNamePortion));
                 modLink = modLink.Substring(0, idx + 1) + fileNamePortion;
             }
 

--- a/Shared/Services/NftMetadataService.cs
+++ b/Shared/Services/NftMetadataService.cs
@@ -35,6 +35,8 @@ namespace Lexplorer.Services
             GC.SuppressFinalize(this);
         }
 
+        public string IPFSBaseUrl { get { return _ipfsBaseUrl; } }
+
         public string? MakeIPFSLink(string? link)
         {
             if (link == null) return null;

--- a/xUnitTests/NFTMetaDataTests/TestNFTMetaData.cs
+++ b/xUnitTests/NFTMetaDataTests/TestNFTMetaData.cs
@@ -122,6 +122,16 @@ namespace xUnitTests.NFTMetaDataTests
             Assert.Equal("Test", meta!.name);
             Assert.Equal("value", meta!.properties!["test"]);
         }
+
+        [Theory]
+        [InlineData("ipfs://QmPbU7P8DmsGAspVrc4hdPXF5Z6P3NTXZfZJ9Q8sBmax9s/AOJETFinal#1.glb", "QmPbU7P8DmsGAspVrc4hdPXF5Z6P3NTXZfZJ9Q8sBmax9s/AOJETFinal%231.glb")]
+        [InlineData("ipfs://ipfs/QmWLmY3Vif95cvMGNkkJDNJjyq7Z8YFLD8ngfuPs89SvWn", "QmWLmY3Vif95cvMGNkkJDNJjyq7Z8YFLD8ngfuPs89SvWn")]
+        [InlineData("ipfs://QmT4enyxCxNytCcby23K8vtBhwteJVy7EJ1KjJhYaEVvhZ/Jolly Roger %230865.mp4", "QmT4enyxCxNytCcby23K8vtBhwteJVy7EJ1KjJhYaEVvhZ/Jolly%20Roger%20%230865.mp4")]
+        public void MakeIPFSLink(string IPFSUrl, string realtivePinataURL)
+        {
+			var url = fixture.NMS.MakeIPFSLink(IPFSUrl);
+            Assert.Equal(fixture.NMS.IPFSBaseUrl + realtivePinataURL, url);
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #242 

1. When adding exception message to NftMetaData.error, avoid adding the same error again and again. This is necessary because these errors are not cached so they will occur every time the page is loaded.
2. When escaping a IPFS URL - which needs escaping - unescape it first, then escape again. Fixes partially escaped URLs. This makes NFT `0x17a84412503e323fb35a378d04a3dd16be46632c7b98db52082f40e369f84e47` work again.

Now there's only one special case left which we cannot handle: a unescaped URL using % and numbers as if it would be escaped. But that couldn't really be fixed by anyone. And strictly speaking these are all mint errors.