### PR TITLE
Store original meta data URL in NftMetadata and show it

### DIFF
--- a/Lexplorer/Pages/NFTDetail.razor
+++ b/Lexplorer/Pages/NFTDetail.razor
@@ -55,12 +55,34 @@
             <td Style="word-break:break-all;"><L1AccountLink address="@nft?.token" shortenAddress="false" /></td>
         </tr>
         <tr>
+            <td>MetaData URL</td>
+            <td Style="word-break:break-all;">
+                @if (@nftMetadata?.URL != null)
+                {
+                    <a Class="mud-theme-primary" href="@nftMetadata?.GatewayURL" target="_blank">@nftMetadata?.URL</a>
+                    <MudIcon Icon="@Icons.Filled.Link" Color="Color.Primary" Title="Link to IPFS gateway" Size="Size.Small" />
+                }
+            </td>
+        </tr>
+        <tr>
             <td>Image URL</td>
-            <td Style="word-break:break-all;">@nftMetadata?.image</td>
+            <td Style="word-break:break-all;">
+                @if (@nftMetadata?.image != null)
+                {
+                    <a Class="mud-theme-primary" href="@NftMetadataService.MakeIPFSLink(nftMetadata?.image)" target="_blank">@nftMetadata?.image</a>
+                    <MudIcon Icon="@Icons.Filled.Link" Color="Color.Primary" Title="Link to IPFS gateway" Size="Size.Small" />
+                }
+            </td>
         </tr>
         <tr>
             <td>Animation URL</td>
-            <td Style="word-break:break-all;">@nftMetadata?.animation_url</td>
+            <td Style="word-break:break-all;">
+                @if (@nftMetadata?.animation_url != null)
+                {
+                    <a Class="mud-theme-primary" href="@NftMetadataService.MakeIPFSLink(nftMetadata?.animation_url)" target="_blank">@nftMetadata?.animation_url</a>
+                    <MudIcon Icon="@Icons.Filled.Link" Color="Color.Primary" Title="Link to IPFS gateway" Size="Size.Small" />
+                }
+            </td>
         </tr>
         @if ((nftMetadata?.attributes?.Count > 0) || (nftMetadata?.properties?.Count > 0))
         {

--- a/Shared/Models/NftMetadata.cs
+++ b/Shared/Models/NftMetadata.cs
@@ -24,6 +24,8 @@ namespace Lexplorer.Models
 
         public string? JSONContent { get; set; }
         public string? Error { get; set; }
+        public string? URL { get; set; }
+        public string? GatewayURL { get; set; }
     }
 
     public class NftAttribute


### PR DESCRIPTION
This will help with debugging issues like #248 and it will probably be handy for others too.

All 3 URLs will link to the pinata gateway that we use. The MetaData URL shown is the original URL as returned from the contract, while the link will contain all the modifications that we might make (escaping, adding /metadata.json etc.)

<img width="754" alt="image" src="https://user-images.githubusercontent.com/44807458/184539285-c6d9a1bc-56e8-4cd9-88c2-c49742acbd27.png">