### PR TITLE
Refactor nft content type tests

### DIFF
--- a/xUnitTests/NFTMetaDataTests/TestNFTMetaData.cs
+++ b/xUnitTests/NFTMetaDataTests/TestNFTMetaData.cs
@@ -21,7 +21,6 @@ namespace xUnitTests.NFTMetaDataTests
 		[InlineData("0x01346618000000000000000002386f26fc1000000000000000000000000003a1", "0x1cacc96e5f01e2849e6036f25531a9a064d2fb5f", 0)] //loophead #929
 		[InlineData("0x01346618000000000000000002386f26fc10000000000000000000000000028d", "0x1cacc96e5f01e2849e6036f25531a9a064d2fb5f", 0)] //loophead #653
 		[InlineData("0x0000000000000000000000000000000000000000000000000000000000000006", "0x6a7ab7711adcfe67141df82ae853787ca93a7797", 0)] //metadata on arweave
-
 		public async void TestGetMetadata(string nftID, string nftTokenAddress, int nftType)
         {
 			var link = await fixture.EthS.GetMetadataLink(nftID, nftTokenAddress, nftType);
@@ -33,74 +32,16 @@ namespace xUnitTests.NFTMetaDataTests
         }
 
 		[Theory]
-		[InlineData("0x4de8f2002b80be98ccab8746c6569850a36b9f5de85b2900f846fa6134bfc8b7", EthereumService.CF_NFTTokenAddress, 0)]
-		public async void TestGetMetadataVideoContentType(string nftID, string nftTokenAddress, int nftType)
+        [InlineData("ipfs://QmRJEhmpwKEn8U6NsHfqGt4ZXZKZm3vFpgRn269d5WsA5y", "video/mp4")] //0x4de8f2002b80be98ccab8746c6569850a36b9f5de85b2900f846fa6134bfc8b7
+        [InlineData("ipfs://QmXo39B4QLDjaaGBNVkQVTqKQPuUvr1dz9DV48n94c5VJm", "image/jpeg")] //0x2b5c4503e39e88154bcafe015fafbaf61955a88d3e65ab2f3aad28e37124c74c
+        [InlineData("ipfs://bafybeigbqythqw23mn3lugl7ae4nnoab2zkevapiff5lxx5hb2hngfhpwi", "audio/mpeg")] //0x52ed914d080ee393a35b02cc9e57f27fa96cc9ab933ee754b05ab61d49539546
+        [InlineData("ipfs://QmdsJy2BehwHfMw34XneTmcmMAJin59uv9Lmw2tFCNKVin/3d.glb", "application/octet-stream", "model/gltf-binary")] //0xf11780791dfef9ca79a07f046e98ef0efdebecfaa763b24eb61ccaaca3132d32
+        [InlineData("ipfs://QmYixrWjyLXEuaNsovWYW6tsrH3NVjRwJ7kUsTPGqZWKvS", "text/html")] //0x574e9ca4605e4ebff1d4e9b204b16fe73f122f82c60da0186af3ded68bff9c10
+        public async void TestGetNFTContentType(string nftURL, params string[] contentTypes)
 		{
-			var link = await fixture.EthS.GetMetadataLink(nftID, nftTokenAddress, nftType);
-			Assert.NotNull(link);
-
-			var meta = await fixture.NMS.GetMetadata(link!);
-			Assert.NotNull(meta);
-
-			var contentType = await fixture.NMS.GetContentTypeFromURL(meta!.animation_url!);
-			Assert.Equal("video/mp4", contentType);
-		}
-
-		[Theory]
-		[InlineData("0x2b5c4503e39e88154bcafe015fafbaf61955a88d3e65ab2f3aad28e37124c74c", EthereumService.CF_NFTTokenAddress, 0)]
-		public async void TestGetMetadataImageContentType(string nftID, string nftTokenAddress, int nftType)
-		{
-			var link = await fixture.EthS.GetMetadataLink(nftID, nftTokenAddress, nftType);
-			Assert.NotNull(link);
-
-			var meta = await fixture.NMS.GetMetadata(link!);
-			Assert.NotNull(meta);
-
-			var contentType = await fixture.NMS.GetContentTypeFromURL(meta!.animation_url!);
-			Assert.Equal("image/jpeg", contentType);
-		}
-
-		[Theory]
-		[InlineData("0x52ed914d080ee393a35b02cc9e57f27fa96cc9ab933ee754b05ab61d49539546", EthereumService.CF_NFTTokenAddress, 0)]
-		public async void TestGetMetadataAudioContentType(string nftID, string nftTokenAddress, int nftType)
-		{
-			var link = await fixture.EthS.GetMetadataLink(nftID, nftTokenAddress, nftType);
-			Assert.NotNull(link);
-
-			var meta = await fixture.NMS.GetMetadata(link!);
-			Assert.NotNull(meta);
-
-			var contentType = await fixture.NMS.GetContentTypeFromURL(meta!.animation_url!);
-			Assert.Equal("audio/mpeg", contentType);
-		}
-
-		[Theory]
-		[InlineData("0xf11780791dfef9ca79a07f046e98ef0efdebecfaa763b24eb61ccaaca3132d32", EthereumService.CF_NFTTokenAddress, 0)]
-		public async void TestGetMetadataModelContentType(string nftID, string nftTokenAddress, int nftType)
-		{
-			var link = await fixture.EthS.GetMetadataLink(nftID, nftTokenAddress, nftType);
-			Assert.NotNull(link);
-
-			var meta = await fixture.NMS.GetMetadata(link!);
-			Assert.NotNull(meta);
-
-
-			var contentType = await fixture.NMS.GetContentTypeFromURL(meta!.animation_url!);
-			Assert.True(new List<string> { "application/octet-stream", "model/gltf-binary" }.Contains(contentType!), $"unexpected contentType \"{contentType}\"");
-		}
-
-		[Theory]
-		[InlineData("0x574e9ca4605e4ebff1d4e9b204b16fe73f122f82c60da0186af3ded68bff9c10", EthereumService.CF_NFTTokenAddress, 0)]
-		public async void TestGetMetadataHtmlContentType(string nftID, string nftTokenAddress, int nftType)
-		{
-			var link = await fixture.EthS.GetMetadataLink(nftID, nftTokenAddress, nftType);
-			Assert.NotNull(link);
-
-			var meta = await fixture.NMS.GetMetadata(link!);
-			Assert.NotNull(meta);
-
-			var contentType = await fixture.NMS.GetContentTypeFromURL(meta!.animation_url!);
-			Assert.Equal("text/html", contentType);
+            var contentType = await fixture.NMS.GetContentTypeFromURL(nftURL);
+			Assert.NotNull(contentType);
+            Assert.Contains(contentType, new List<string>(contentTypes));
 		}
 
         [Fact]

--- a/xUnitTests/NFTMetaDataTests/TestNFTMetaData.cs
+++ b/xUnitTests/NFTMetaDataTests/TestNFTMetaData.cs
@@ -31,18 +31,18 @@ namespace xUnitTests.NFTMetaDataTests
 			Assert.Null(meta!.Error);
         }
 
-		[Theory]
+        [Theory]
         [InlineData("ipfs://QmRJEhmpwKEn8U6NsHfqGt4ZXZKZm3vFpgRn269d5WsA5y", "video/mp4")] //0x4de8f2002b80be98ccab8746c6569850a36b9f5de85b2900f846fa6134bfc8b7
         [InlineData("ipfs://QmXo39B4QLDjaaGBNVkQVTqKQPuUvr1dz9DV48n94c5VJm", "image/jpeg")] //0x2b5c4503e39e88154bcafe015fafbaf61955a88d3e65ab2f3aad28e37124c74c
         [InlineData("ipfs://bafybeigbqythqw23mn3lugl7ae4nnoab2zkevapiff5lxx5hb2hngfhpwi", "audio/mpeg")] //0x52ed914d080ee393a35b02cc9e57f27fa96cc9ab933ee754b05ab61d49539546
         [InlineData("ipfs://QmdsJy2BehwHfMw34XneTmcmMAJin59uv9Lmw2tFCNKVin/3d.glb", "application/octet-stream", "model/gltf-binary")] //0xf11780791dfef9ca79a07f046e98ef0efdebecfaa763b24eb61ccaaca3132d32
         [InlineData("ipfs://QmYixrWjyLXEuaNsovWYW6tsrH3NVjRwJ7kUsTPGqZWKvS", "text/html")] //0x574e9ca4605e4ebff1d4e9b204b16fe73f122f82c60da0186af3ded68bff9c10
         public async void TestGetNFTContentType(string nftURL, params string[] contentTypes)
-		{
+        {
             var contentType = await fixture.NMS.GetContentTypeFromURL(nftURL);
-			Assert.NotNull(contentType);
+            Assert.NotNull(contentType);
             Assert.Contains(contentType, new List<string>(contentTypes));
-		}
+        }
 
         [Fact]
 		public void TestCorrectJSONPropertiesDictionary()


### PR DESCRIPTION
1. Instead of one theory per content type, a single theory for all.
2. Instead of first fetching the MetaData URL and then the metadata, feed the theory directly with the animation_urls.

Especially the 2nd part might also make these tests fail less often, as only one IPFS fetch is required.