### PR TITLE
Fix NFT holder export skip limit

### DIFF
--- a/Lexplorer/Pages/NFTDetail.razor
+++ b/Lexplorer/Pages/NFTDetail.razor
@@ -413,8 +413,8 @@
         errorMessage = null;
         try
         {
-            var fileName = $"NftHolders_{nftId}_{DateTime.UtcNow}.txt";
-            var fileStream = await NFTHolderExportService.GenerateCSV(nftId);
+            var fileName = $"NftHolders_{nft!.nftID}_{DateTime.UtcNow:yyyyMMddTHHmmss}.txt";
+            var fileStream = await NFTHolderExportService.GenerateCSV(nftId, nft);
 
             using var streamRef = new DotNetStreamReference(stream: fileStream);
 

--- a/Shared/Services/LoopringGraphQLService.cs
+++ b/Shared/Services/LoopringGraphQLService.cs
@@ -1481,7 +1481,9 @@ namespace Lexplorer.Services
             }
         }
 
-        public async Task<List<AccountNFTSlot>> GetNftHolders(string nftId, int skip = 0, int first = 25, string orderBy = "balance", string orderDirection = "desc", CancellationToken cancellationToken = default)
+        public async Task<List<AccountNFTSlot>> GetNftHolders(string nftId, int skip = 0, int first = 25,
+            string orderBy = "balance", string orderDirection = "desc", object? slotWhere = null,
+            CancellationToken cancellationToken = default)
         {
             var nftHolders = @"
             query nftHolders(
@@ -1490,6 +1492,7 @@ namespace Lexplorer.Services
                 $nftId: String
                 $orderBy: String
                 $orderDirection: String
+                $slotWhere: AccountNFTSlot_filter
             )
             {
                 nonFungibleToken(
@@ -1501,13 +1504,15 @@ namespace Lexplorer.Services
                         first: $first
                         orderBy: $orderBy
                         orderDirection: $orderDirection
+                        where: $slotWhere
                     ) 
                     {
+                        id
                         account {
                             id
                             address
                         }
-                    balance
+                        balance
                     }
                 }
              }";
@@ -1523,7 +1528,8 @@ namespace Lexplorer.Services
                     skip = skip,
                     nftId = nftId,
                     orderBy = orderBy,
-                    orderDirection = orderDirection
+                    orderDirection = orderDirection,
+                    slotWhere = slotWhere
                 }
             });
             request.AddStringBody(jObject.ToString(), ContentType.Json);

--- a/Shared/Services/NFTHolderExportService.cs
+++ b/Shared/Services/NFTHolderExportService.cs
@@ -19,17 +19,28 @@ namespace Lexplorer.Services
             _graphqlService = graphQLService;
         }
 
-        public async Task<Stream> GenerateCSV(string nftId)
+        public async Task<Stream> GenerateCSV(string nftId, NonFungibleToken? nft)
         {
             var stream = new MemoryStream();
             using (var writer = new StreamWriter(stream, leaveOpen: true))
             {
                 CSVWriteLine writeLine = (string line) => writer.WriteLine(line);
-                DoWriteLine(writeLine, "NftId", "Address", "Balance");
+                //write header
+                if (nft != null)
+                {
+                    DoWriteLine(writeLine, "NftId", nft.nftID);
+                    DoWriteLine(writeLine, "NftType", nft.nftTypeName);
+                    DoWriteLine(writeLine, "Token", nft.token);
+                    DoWriteLine(writeLine, "Minter", nft.minter?.id);
+                    DoWriteLine(writeLine, "MintedAt", nft.mintedAtTransaction?.id);
+                    DoWriteLine(writeLine, "MintedAmount", nft.mintedAtTransaction?.amount.ToString());
+                    writeLine("");
+                }
+                DoWriteLine(writeLine, "Account", "Address", "Balance");
                 string? lastSlotID = null;
                 while (true)
                 {
-                    const int chunkSize = 10;
+                    const int chunkSize = 200;
                     IList<AccountNFTSlot>? holders = await _graphqlService.GetNftHolders(nftId, 0, chunkSize, "id", "asc",
                         lastSlotID == null ? null : new { id_gt = lastSlotID })!;
                     if ((holders == null) || (holders.Count == 0))
@@ -40,7 +51,7 @@ namespace Lexplorer.Services
                     }
                     foreach (var holder in holders)
                     {
-                        DoWriteLine(writeLine, nftId, holder.account!.address!, holder.balance.ToString());
+                        DoWriteLine(writeLine, holder.account!.id, holder.account!.address!, holder.balance.ToString());
                     }
                     if (holders.Count < chunkSize) break;
                     lastSlotID = holders.Last().id;


### PR DESCRIPTION
Fixes #254

* ordering ascending by slot id
* instead of using skip, pass in last slot id and filter with id_gt
* sped up export by fetching 200 holders with each query instead of just 10
* remove nftID from csv rows (same for all!) but include account id instead
* add header section with helpful details about the NFT
* better export filename, using nftID instead of .id and more compact UTC timestamp