### PR TITLE
Fix transaction export skip limit

### DIFF
--- a/Shared/Services/LoopringGraphQLService.cs
+++ b/Shared/Services/LoopringGraphQLService.cs
@@ -576,7 +576,7 @@ namespace Lexplorer.Services
         }
 
         public async Task<string?> GetAccountTransactionsResponse(int skip, int first, string accountId,
-            double? firstBlockId = null, double? lastBlockId = null, CancellationToken cancellationToken = default)
+            object? where = null, CancellationToken cancellationToken = default)
         {
             var accountQuery = @"
             query accountTransactions(
@@ -636,17 +636,9 @@ namespace Lexplorer.Services
                     accountId = int.Parse(accountId),
                     orderBy = "internalID",
                     orderDirection = "desc",
-                    where = new
-                    {
-                    },
+                    where = where
                 }
             });
-            if (firstBlockId.HasValue && lastBlockId.HasValue)
-            {
-                JObject where = (jObject["variables"]!["where"] as JObject)!;
-                where.Add(new JProperty("block_gte", firstBlockId.ToString()));
-                where.Add(new JProperty("block_lte", lastBlockId.ToString()));
-            }
             request.AddStringBody(jObject.ToString(), ContentType.Json);
             try
             {
@@ -661,11 +653,11 @@ namespace Lexplorer.Services
         }
 
         public async Task<IList<Transaction>?> GetAccountTransactions(int skip, int first, string accountId,
-            double? firstBlockId = null, double? lastBlockId = null, CancellationToken cancellationToken = default)
+            object? where = null, CancellationToken cancellationToken = default)
         {
             try
             {
-                string? response = await GetAccountTransactionsResponse(skip, first, accountId, firstBlockId, lastBlockId, cancellationToken);
+                string? response = await GetAccountTransactionsResponse(skip, first, accountId, where, cancellationToken);
                 JObject jresponse = JObject.Parse(response!);
                 JToken? token = jresponse["data"]!["account"]!["transactions"];
                 return token!.ToObject<IList<Transaction>>();

--- a/Shared/Services/LoopringGraphQLService.cs
+++ b/Shared/Services/LoopringGraphQLService.cs
@@ -598,6 +598,7 @@ namespace Lexplorer.Services
                     where: $where
                   ) {
                     id
+                    internalID
                     __typename
                     block {
                       timestamp

--- a/Shared/Services/TransactionExportDefaultCSVFormat.cs
+++ b/Shared/Services/TransactionExportDefaultCSVFormat.cs
@@ -67,6 +67,7 @@ namespace Lexplorer.Services
                     );
             }
         }
+
         private void WriteSwap(Swap swap, string accountIdPerspective, CSVWriteLine writeLine)
         {
             if (swap.fillAmountBorSA)
@@ -89,6 +90,7 @@ namespace Lexplorer.Services
                     );
             }
         }
+
         private void WriteTransfer(Transfer transfer, string accountIdPerspective, CSVWriteLine writeLine)
         {
             DoBuildLine(transfer, transfer.id, transfer.verifiedAt, transfer.typeName,
@@ -101,6 +103,7 @@ namespace Lexplorer.Services
                 total: (transfer.fromAccount?.id == accountIdPerspective) ? GetExportAmount(transfer.amount, transfer.token) : null,
                 totalToken: (transfer.fromAccount?.id  == accountIdPerspective) ? transfer.token?.symbol : null);
         }
+
         private void WriteDeposit(Deposit deposit, string accountIdPerspective, CSVWriteLine writeLine)
         {
             DoBuildLine(deposit, deposit.id, deposit.verifiedAt, deposit.typeName,
@@ -108,6 +111,7 @@ namespace Lexplorer.Services
                 added: GetExportAmount(deposit.amount, deposit.token),
                 addedToken: deposit.token?.symbol);
         }
+
         private void WriteWithdrawal(Withdrawal withdrawal, string accountIdPerspective, CSVWriteLine writeLine)
         {
             DoBuildLine(withdrawal, withdrawal.id, withdrawal.verifiedAt, withdrawal.typeName,
@@ -115,6 +119,7 @@ namespace Lexplorer.Services
                 total: GetExportAmount(withdrawal.amount, withdrawal.token),
                 totalToken: withdrawal.token?.symbol);
         }
+
         private void WriteAccountUpdate(AccountUpdate accountUpdate, string accountIdPerspective, CSVWriteLine writeLine)
         {
             DoBuildLine(accountUpdate, accountUpdate.id, accountUpdate.verifiedAt, accountUpdate.typeName, 
@@ -122,6 +127,7 @@ namespace Lexplorer.Services
                 fee: GetExportAmount(accountUpdate.fee, accountUpdate.feeToken),
                 feeToken: accountUpdate.feeToken?.symbol);
         }
+
         private void WriteTransferNFT(TransferNFT transferNFT, string accountIdPerspective, CSVWriteLine writeLine)
         {
             DoBuildLine(transferNFT, transferNFT.id, transferNFT.verifiedAt, transferNFT.typeName,
@@ -134,6 +140,7 @@ namespace Lexplorer.Services
                 total: (transferNFT.fromAccount?.id == accountIdPerspective) ? transferNFT.amount.ToString() : null,
                 totalToken: (transferNFT.fromAccount?.id == accountIdPerspective) ? "NFT" : null);
         }
+
         private void WriteMintNFT(MintNFT mintNFT, string accountIdPerspective, CSVWriteLine writeLine)
         {
             DoBuildLine(mintNFT, mintNFT.id, mintNFT.verifiedAt, mintNFT.typeName,
@@ -146,6 +153,7 @@ namespace Lexplorer.Services
                 total: (mintNFT.minter?.id == accountIdPerspective) && (mintNFT.minter?.id != mintNFT.receiver?.id) ? mintNFT.amount.ToString() : null,
                 totalToken: (mintNFT.minter?.id == accountIdPerspective) && (mintNFT.minter?.id != mintNFT.receiver?.id) ? "NFT" : null);
         }
+
         private void WriteWithdrawalNFT(WithdrawalNFT withdrawalNFT, string accountIdPerspective, CSVWriteLine writeLine)
         {
             DoBuildLine(withdrawalNFT, withdrawalNFT.id, withdrawalNFT.verifiedAt, withdrawalNFT.typeName,
@@ -158,11 +166,13 @@ namespace Lexplorer.Services
                 total: (withdrawalNFT.fromAccount?.id == accountIdPerspective) ? withdrawalNFT.amount.ToString() : null,
                 totalToken: (withdrawalNFT.fromAccount?.id == accountIdPerspective) ? "NFT" : null);
         }
+
         private static readonly List<string> transactionTypesToIgnore = new()
         {
             { "SignatureVerification" },
             { "AmmUpdate" }
         };
+
         public void WriteTransaction(Transaction transaction, string accountIdPerspective, CSVWriteLine writeLine)
         {
             sb.Clear();
@@ -185,9 +195,7 @@ namespace Lexplorer.Services
             else if (transaction is AccountUpdate accountUpdate)
                 WriteAccountUpdate(accountUpdate, accountIdPerspective, writeLine);
             else if (transactionTypesToIgnore.Contains(transaction.typeName!))
-#pragma warning disable CS0642 // Possible mistaken empty statement
-                ; //nothing to export
-#pragma warning restore CS0642 // Possible mistaken empty statement
+                return; //nothing to export
             else
                 sb.AppendJoin(Convert.ToChar(9), transaction.id, transaction.verifiedAt, transaction.typeName);
 

--- a/Shared/Services/TransactionExportService.cs
+++ b/Shared/Services/TransactionExportService.cs
@@ -61,8 +61,8 @@ namespace Lexplorer.Services
                 while (true)
                 {
                     const int chunkSize = 10;
-                    IList<Transaction>? transactions = await _graphqlService.GetAccountTransactions(processed, chunkSize, 
-                        accountId, blockIds!.Item1, blockIds!.Item2)!;
+                    IList<Transaction>? transactions = await _graphqlService.GetAccountTransactions(processed, chunkSize,
+                        accountId, new { block_gte = blockIds!.Item1.ToString(), block_lte = blockIds!.Item2.ToString() })!;
                     if ((transactions == null) || (transactions.Count == 0))
                     {
                         if (processed == 0)

--- a/Shared/Services/TransactionExportService.cs
+++ b/Shared/Services/TransactionExportService.cs
@@ -57,15 +57,18 @@ namespace Lexplorer.Services
                 CSVWriteLine writeLine = (string line) => writer.WriteLine(line);
                 format.WriteHeader(writeLine);
                 var blockIds = await _graphqlService.GetBlockDateRange(startDate, endDate);
-                var processed = 0;
+                string? lastId = null;
+                object? whereObject = null;
                 while (true)
                 {
-                    const int chunkSize = 10;
-                    IList<Transaction>? transactions = await _graphqlService.GetAccountTransactions(processed, chunkSize,
-                        accountId, new { block_gte = blockIds!.Item1.ToString(), block_lte = blockIds!.Item2.ToString() })!;
+                    const int chunkSize = 1000;
+                    whereObject = (lastId == null) ?
+                        new { block_gte = blockIds!.Item1.ToString(), block_lte = blockIds!.Item2.ToString() } :
+                        new { block_gte = blockIds!.Item1.ToString(), block_lte = blockIds!.Item2.ToString(), internalID_lt = lastId };
+                    IList<Transaction>? transactions = await _graphqlService.GetAccountTransactions(0, chunkSize, accountId, whereObject)!;
                     if ((transactions == null) || (transactions.Count == 0))
                     {
-                        if (processed == 0)
+                        if (lastId == null)
                             throw new Exception("No transactions found in the given timespan");
                         break;
                     }
@@ -74,7 +77,7 @@ namespace Lexplorer.Services
                         format.WriteTransaction(transaction, accountId, writeLine);
                     }
                     if (transactions.Count < chunkSize) break;
-                    processed += chunkSize;
+                    lastId = transactions.Last().internalID;
                 }
             }
             stream.Position = 0;

--- a/xUnitTests/LoopringGraphTests/TestAccountTransactions.cs
+++ b/xUnitTests/LoopringGraphTests/TestAccountTransactions.cs
@@ -36,7 +36,7 @@ namespace xUnitTests.LoopringGraphTests
 
             var blockIds = await service.GetBlockDateRange(startDate, endDate);
             var response = await service.GetAccountTransactionsResponse(0, 100, fixture.testAccountId,
-              blockIds!.Item1, blockIds!.Item2);
+              new { block_gte = blockIds!.Item1.ToString(), block_lte = blockIds!.Item2.ToString() });
             Assert.NotNull(response);
             JObject jresponse = JObject.Parse(response!);
             JToken token = jresponse["data"]!["account"]!["transactions"]!;

--- a/xUnitTests/LoopringGraphTests/TestAccountTransactions.cs
+++ b/xUnitTests/LoopringGraphTests/TestAccountTransactions.cs
@@ -36,7 +36,7 @@ namespace xUnitTests.LoopringGraphTests
 
             var blockIds = await service.GetBlockDateRange(startDate, endDate);
             var response = await service.GetAccountTransactionsResponse(0, 100, fixture.testAccountId,
-              new { block_gte = blockIds!.Item1.ToString(), block_lte = blockIds!.Item2.ToString() });
+                where: new { block_gte = blockIds!.Item1.ToString(), block_lte = blockIds!.Item2.ToString() });
             Assert.NotNull(response);
             JObject jresponse = JObject.Parse(response!);
             JToken token = jresponse["data"]!["account"]!["transactions"]!;


### PR DESCRIPTION
Fixes #254 

* similar approach to what was done for NFT holder export in #255 
* instead of using skip and processed counter, use lastID and internalID filtering
* increased chunk size to 1000, so most people will probably only need one chunk :)
* tested with exporting a months worth of LRC/USDC pool (no. 108) transactions - almost 24k transactions in what felt like less than a minute
* also fixed empty lines in exports for ignored transaction (SignatureVerification, AmmUpdate)