### PR TITLE
fix the ordering of the account nft slots due to the recent subgraph …

### DIFF
--- a/Shared/Services/LoopringGraphQLService.cs
+++ b/Shared/Services/LoopringGraphQLService.cs
@@ -710,7 +710,7 @@ namespace Lexplorer.Services
                 {
                     skip = skip,
                     first = first,
-                    orderBy = "lastUpdatedAt",
+                    orderBy = "id",
                     orderDirection = "desc",
                     where = new
                     {

--- a/Shared/Services/LoopringGraphQLService.cs
+++ b/Shared/Services/LoopringGraphQLService.cs
@@ -710,7 +710,7 @@ namespace Lexplorer.Services
                 {
                     skip = skip,
                     first = first,
-                    orderBy = "id",
+                    orderBy = "createdAt",
                     orderDirection = "desc",
                     where = new
                     {


### PR DESCRIPTION
fix #258 

changed the orderBy in accountNftSlot graph query to "createdAt"

Before for my account id of 40940:
![image](https://user-images.githubusercontent.com/5258063/187340124-a3cec2bf-d728-480f-aad9-7c214b654c09.png)

Now after the change:
![image](https://user-images.githubusercontent.com/5258063/187340170-1accd11b-b661-428b-8d86-d3d7032304e3.png)

Now matches my loopring.io wallet details too:
![image](https://user-images.githubusercontent.com/5258063/187340233-933f3615-3fee-4f4f-8b75-6baf45b6eab4.png)
