### PR TITLE
Convert collection token ID string to lowercase when querying graph

### DIFF
--- a/Shared/Services/LoopringGraphQLService.cs
+++ b/Shared/Services/LoopringGraphQLService.cs
@@ -1386,7 +1386,9 @@ namespace Lexplorer.Services
                 {
                     where = new 
                     {
-                        token_in = new List<string> { tokenAddress } //avoid invalid argument error with graph when using "token" string instead of "token_in"
+                        //avoid invalid argument error with graph when using "token" string instead of "token_in"
+                        //also: convert to lower case, otherwise graph just returns an empty list, see #263
+                        token_in = new List<string> { tokenAddress.ToLower() }
                     },
                     skip = skip,
                     first = first,

--- a/xUnitTests/LoopringGraphTests/TestNFT.cs
+++ b/xUnitTests/LoopringGraphTests/TestNFT.cs
@@ -64,6 +64,7 @@ namespace xUnitTests.LoopringGraphTests
 
         [Theory]
         [InlineData("0x9af1b4f94657c79c4cff77c3c35a746353518724")]
+        [InlineData("0x7F49fc64A8dA0735C68557f3aEd37E377CF8F6a5")]
         public async void GetCollectionNFTs(string tokenAddress)
         {
             var nfts = await service.GetCollectionNFTs(tokenAddress);


### PR DESCRIPTION
* added address from bug report to test-case
* this is the official case-sensitive form of that contract address as seen on etherscan
* still, the graph will silently fail and just return an empty set
* converting token address to lowercase fixes graph

Fixes #263